### PR TITLE
Implement single-cycle RV64I core

### DIFF
--- a/design/alu.sv
+++ b/design/alu.sv
@@ -13,6 +13,12 @@
 /*
  * Module: ALU
  *
+ * Pure combinational arithmetic/logic unit, WORD_SIZE (XLEN) bits wide --
+ * except the RV64I "*W" ops below, which always operate on 32 bits
+ * regardless of WORD_SIZE. See the comment above their `define`s in
+ * defaults/alu_ops.sv for why those can't just be SLL/SRL/SRA fed
+ * truncated operands.
+ *
  * Input ports:
  *  i_operand_A: Source 1 (rs1) in instruction.
  *  i_operation: The operation to perform (A op B).
@@ -28,6 +34,42 @@ module alu (
 
     output logic    [(`WORD_SIZE - 1):0]    o_result
 );
+    /*
+     * RV64I "*W" intermediate results. Computed unconditionally rather than
+     * inside the case arms below -- it's cheap combinational logic that
+     * synthesizes away entirely when unused, and keeps the case arms
+     * themselves down to one line each. Shift amount is a fixed 5 bits
+     * here (not L2_WORD_SIZE): these ops are always 32-bit, regardless of
+     * WORD_SIZE, so the shift amount field is always 5 bits wide too.
+     */
+    logic [31:0] w_sll_result, w_srl_result, w_sra_result;
+    assign w_sll_result = i_operand_A[31:0] << i_operand_B[4:0];
+    assign w_srl_result = i_operand_A[31:0] >> i_operand_B[4:0];
+    assign w_sra_result = $signed(i_operand_A[31:0]) >>> i_operand_B[4:0];
+
+    /*
+     * Sign-extended to WORD_SIZE here, via plain `assign` rather than
+     * inside the always_comb block below -- Icarus Verilog doesn't fully
+     * support constant bit-selects (w_sll_result[31], etc.) inside
+     * always_* processes (falls back to treating the process as sensitive
+     * to the whole vector; harmless for a combinational block, but noisy
+     * and worth just avoiding).
+     */
+    logic [(`WORD_SIZE - 1):0] w_sll_result_ext, w_srl_result_ext, w_sra_result_ext;
+    assign w_sll_result_ext = {{32{w_sll_result[31]}}, w_sll_result};
+    assign w_srl_result_ext = {{32{w_srl_result[31]}}, w_srl_result};
+    assign w_sra_result_ext = {{32{w_sra_result[31]}}, w_sra_result};
+
+    /*
+     * Full-width shift amount, masked -- same reason as the *W results
+     * above: precomputed via plain assign, not inline inside the
+     * always_comb case statement below, since Icarus Verilog doesn't
+     * fully support constant selects (i_operand_B[...]) inside always_*
+     * processes either way.
+     */
+    logic [(`L2_WORD_SIZE - 1):0] shamt_masked;
+    assign shamt_masked = i_operand_B[(`L2_WORD_SIZE - 1):0];
+
     always_comb begin: alu_ops
         case (i_operation)
 
@@ -41,14 +83,55 @@ module alu (
         `XOR:   o_result = i_operand_A ^ i_operand_B;
         `NOT:   o_result = ~i_operand_A;    /* Unary */
 
-        /* Comparison operations */
-        `SLTU:  o_result = i_operand_A < i_operand_B;
-        `SLT:   o_result = (~i_operand_A + 1) < (~i_operand_B + 1);
+        /*
+         * Comparison operations. Both produce a 1-bit true/false that
+         * needs zero-extending to the full WORD_SIZE result per spec (rd =
+         * 1 or 0, using the whole register) -- cast explicitly rather than
+         * relying on the implicit 1-to-WORD_SIZE-bit expansion, which
+         * verilator otherwise (correctly) flags as a width mismatch to
+         * double check, even though it's intentional here.
+         */
+        `SLTU:  o_result = `WORD_SIZE'(i_operand_A < i_operand_B);
+        /*
+         * SLT compares as signed. The old (~A+1) < (~B+1) trick negates
+         * both operands and compares unsigned, but that's wrong whenever
+         * an operand is the most negative representable value -- negating
+         * INT_MIN overflows back to itself in two's complement, since
+         * there's no positive counterpart to negate to. $signed()
+         * reinterprets the same bits as signed for this comparison only;
+         * it doesn't change what's stored anywhere.
+         */
+        `SLT:   o_result = `WORD_SIZE'($signed(i_operand_A) < $signed(i_operand_B));
 
-        /* Shift operations */
-        `SLL:   o_result = i_operand_A << i_operand_B;
-        `SRL:   o_result = i_operand_A >> i_operand_B;
-        `SRA:   o_result = i_operand_A >>> i_operand_B;
+        /*
+         * Shift operations. Shift amount is masked to L2_WORD_SIZE bits
+         * (6, since WORD_SIZE is 64) per spec: shamt for a full-width
+         * shift is defined as exactly log2(XLEN) bits, so an amount at or
+         * beyond the operand width wraps rather than being treated as a
+         * shift hardware can't actually perform.
+         */
+        `SLL:   o_result = i_operand_A << shamt_masked;
+        `SRL:   o_result = i_operand_A >> shamt_masked;
+        /*
+         * Same $signed() cast as SLT, for the same underlying reason: >>>
+         * only sign-extends if its LEFT operand's type is signed. Without
+         * the cast, i_operand_A is a plain unsigned `logic`, so >>> would
+         * silently degrade into an ordinary logical shift -- SRA would
+         * behave identically to SRL instead of replicating the sign bit.
+         */
+        `SRA:   o_result = $signed(i_operand_A) >>> shamt_masked;
+
+        /*
+         * RV64I word ops: sign-extend the 32-bit result computed above.
+         * This sign-extension applies uniformly to all three per spec --
+         * notably SRLW ("logical" shift, zero-fills DURING the shift)
+         * still SIGN-extends its final 32-to-64 result, same as SRAW.
+         * "Logical shift" and "zero-extend the result" are two different
+         * steps; only the shift itself is logical here.
+         */
+        `SLLW:  o_result = w_sll_result_ext;
+        `SRLW:  o_result = w_srl_result_ext;
+        `SRAW:  o_result = w_sra_result_ext;
 
         default: o_result = 0;
 

--- a/design/alu_tb.sv
+++ b/design/alu_tb.sv
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+`include "defaults/defaults.sv"
+`include "defaults/alu_ops.sv"
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Testbench: alu
+ *
+ * Unit-level, no clock needed -- the ALU is pure combinational. Each test
+ * vector below was chosen to distinguish the FIXED behaviour from the
+ * SPECIFIC bug it regresses, not just to check "is the answer right" --
+ * see the comment on each case for why that particular input pair matters.
+ */
+module alu_tb;
+
+    logic [(`WORD_SIZE - 1):0]  operand_A, operand_B;
+    logic [(`ALU_OPSIZE - 1):0] operation;
+    logic [(`WORD_SIZE - 1):0]  result;
+
+    alu dut (
+        .i_operand_A(operand_A),
+        .i_operation(operation),
+        .i_operand_B(operand_B),
+        .o_result(result)
+    );
+
+    int pass_count = 0;
+    int fail_count = 0;
+
+    task automatic check(string name, logic [(`WORD_SIZE-1):0] expected);
+        #1; // let the combinational logic settle
+        if (result === expected) begin
+            pass_count++;
+            $display("PASS: %s", name);
+        end else begin
+            fail_count++;
+            $display("FAIL: %s -- expected %h, got %h", name, expected, result);
+        end
+    endtask
+
+    initial begin
+        /*
+         * SLT: old buggy formula was (~A+1) < (~B+1) unsigned. That
+         * formula is NOT algebraically equivalent to a signed compare in
+         * general -- it happens to coincide with the right answer for many
+         * inputs, which is exactly what made the bug easy to miss. Both
+         * cases below were hand-verified to make the OLD formula disagree
+         * with the correct signed answer.
+         */
+
+        // INT64_MIN < 0 is TRUE. Old formula: negating INT64_MIN overflows
+        // back to itself (no positive counterpart in two's complement), so
+        // it compares unsigned(INT64_MIN) < unsigned(0) = huge < 0 = FALSE.
+        operand_A = 64'h8000000000000000; operand_B = 64'h0000000000000000;
+        operation = `SLT;
+        check("SLT: INT64_MIN < 0 (INT_MIN negation-overflow case)", 64'd1);
+
+        // -1 < -2 is FALSE (-1 is the larger of the two). Old formula:
+        // unsigned(-(-1))=1 < unsigned(-(-2))=2 is TRUE -- wrong sign of
+        // the comparison entirely, no INT_MIN involved.
+        operand_A = 64'hFFFFFFFFFFFFFFFF; operand_B = 64'hFFFFFFFFFFFFFFFE;
+        operation = `SLT;
+        check("SLT: -1 < -2 (general negation-trick unsoundness, no INT_MIN)", 64'd0);
+
+        /*
+         * SLT vs SLTU on the identical bit pattern: proves the signed path
+         * is real and distinct, not coincidentally the same as unsigned.
+         */
+        operand_A = 64'h8000000000000000; operand_B = 64'h0000000000000001;
+        operation = `SLT;  // signed: INT64_MIN < 1 -> true
+        check("SLT: INT64_MIN < 1 (signed)", 64'd1);
+        operation = `SLTU; // unsigned: 2^63 < 1 -> false
+        check("SLTU: same bits, unsigned: 2^63 < 1", 64'd0);
+
+        /*
+         * SRA vs SRL on INT64_MIN: if SRA had degraded to SRL (the bug),
+         * this would come back 0x0800000000000000 instead.
+         */
+        operand_A = 64'h8000000000000000; operand_B = 64'd4;
+        operation = `SRA;
+        check("SRA: INT64_MIN >>> 4 sign-extends (0xF8...)", 64'hF800000000000000);
+        operation = `SRL;
+        check("SRL: INT64_MIN >> 4 zero-fills (0x08...)", 64'h0800000000000000);
+
+        /*
+         * Shift-amount masking: WORD_SIZE=64 means only the low 6 bits of
+         * the shift amount are used (log2(64)=6). A raw, unmasked shift by
+         * 64 or 65 would behave very differently (most tools give 0 for a
+         * shift-by->=width); masked, they wrap to shift-by-0 and
+         * shift-by-1 respectively.
+         */
+        operand_A = 64'd1; operand_B = 64'd64; // 64 mod 64 = 0
+        operation = `SLL;
+        check("SLL: shift amount 64 wraps to 0 (no shift)", 64'd1);
+        operand_A = 64'd1; operand_B = 64'd65; // 65 mod 64 = 1
+        operation = `SLL;
+        check("SLL: shift amount 65 wraps to 1", 64'd2);
+
+        /*
+         * RV64I word ops. SLLW: low-32 result's bit 31 ends up 1, so it
+         * sign-extends negative even though the source operand (1) was
+         * positive -- proves the *result's* sign drives the extension,
+         * not the source operand's.
+         */
+        operand_A = 64'd1; operand_B = 64'd31;
+        operation = `SLLW;
+        check("SLLW: 1<<31 = 0x80000000, sign-extends negative", 64'hFFFFFFFF80000000);
+
+        /*
+         * SRLW vs SRAW on the SAME input and shift amount: the shift
+         * itself differs (logical zero-fill vs arithmetic sign-fill), but
+         * BOTH still sign-extend their 32-bit result to 64 bits per spec --
+         * they diverge here because the logical shift's result happens to
+         * have bit 31 = 0, while the arithmetic shift's result keeps bit
+         * 31 = 1. This is the case the header comment in alu.sv warns
+         * about: don't assume "logical" means "zero-extend the result".
+         */
+        operand_A = 64'hFFFFFFFFFFFFFFFF; operand_B = 64'd4;
+        operation = `SRLW;
+        check("SRLW: 0xFFFFFFFF>>4=0x0FFFFFFF, result sign-extends positive", 64'h000000000FFFFFFF);
+        operation = `SRAW;
+        check("SRAW: 0xFFFFFFFF>>>4=0xFFFFFFFF, result sign-extends negative", 64'hFFFFFFFFFFFFFFFF);
+
+        $display("");
+        $display("alu_tb: %0d passed, %0d failed", pass_count, fail_count);
+        if (fail_count > 0) $display("alu_tb: FAILURES PRESENT");
+        $finish;
+    end
+
+endmodule

--- a/design/core.sv
+++ b/design/core.sv
@@ -1,67 +1,419 @@
-module core
-(
-    //Clock is shared with WB4 BUS
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+`include "defaults/defaults.sv"
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Module: core (single-cycle RV64I)
+ *
+ * Every instruction completes fetch through writeback within one clock
+ * edge-to-edge cycle -- there is no FSM here at all. That's only possible
+ * because imem/dmem (below) are purpose-built with combinational reads;
+ * see their own header comments for why a Wishbone-attached memory like
+ * design/wb4_sram.sv couldn't work here (its ack is a registered output,
+ * a minimum 2-edge transaction by construction). Hooking this core up to
+ * a real, registered memory system is a later milestone, not this one.
+ *
+ * decoder/alu/register_file are reused as-is (bugs fixed separately, see
+ * their own files) rather than re-implemented here -- this module is
+ * purely the glue between them: the PC, the control unit that decides
+ * what each of them should do for a given decoded instruction, and the
+ * muxes that route data between them.
+ *
+ * `INSTR_CODE(name)` (used throughout the control logic below) and every
+ * ALU op name (`ADD, `SLTW, etc.) are inherited from decoder.sv's and
+ * alu.sv's own `includes -- not re-included here, since both of those
+ * modules are necessarily compiled/instantiated below already.
+ *
+ * Scope: full RV64I base ISA. No M/A/C extensions, no Zicsr/CSRs, no
+ * privilege modes, no Sv39, no interrupts/exceptions -- all later
+ * milestones. Misaligned access, FENCE, and ECALL are deliberately
+ * under-implemented here (see their handling below) for the same reason.
+ *
+ * Input ports:
+ *  clk: Clock.
+ *  rst: Synchronous reset (active high) -- resets pc to 0 and clears
+ *       `halted`. Does NOT reset register/memory contents; the ISA
+ *       doesn't require it, and real hardware doesn't guarantee it
+ *       either (only the reset vector is architecturally defined).
+ */
+module core (
     input logic clk,
-    input logic rst,
-
-
-    //Wishbone signals
-    output logic [31:0] addr_o,
-    input  logic [31:0] dat_i,
-    output logic [31:0] dat_o,
-
-    input  logic ack_i,
-    input  logic err_i,
-    output logic cyc_o,
-    output logic stb_o,
-    output logic we_o
-
+    input logic rst
 );
-  
-typedef enum logic [1:0] { FETCH, EXECUTE } exec_state_t;
 
-exec_state_t current_state = FETCH;
+    /* --------------------------------------------------------------- *
+     * Fetch
+     * --------------------------------------------------------------- */
 
-logic [64:0] IR = 0;
+    logic [(`WORD_SIZE - 1):0] pc;
+    logic [(`WORD_SIZE - 1):0] next_pc;
 
-wire [6:0]  funct7   = IR[31:25];
-wire [4:0]  rs2      = IR[24:20];
-wire [4:0]  rs1      = IR[19:15];
-wire [2:0]  funct3   = IR[14:12];
-wire [4:0]  rd       = IR[11:7];
-wire [6:0]  opcode   = IR[6:0];
+    logic [(`INSTR_SIZE - 1):0] instruction;
 
-wire [11:0] imm      = IR[31:20];
+    imem imem0 (
+        .i_addr(pc),
+        .o_instruction(instruction)
+    );
 
-wire [6:0]  imm_11_5 = IR[31:25];
-wire [4:0]  imm_4_0  = IR[11:7];
+    /* --------------------------------------------------------------- *
+     * Decode
+     * --------------------------------------------------------------- */
 
-wire [19:0] imm_31_12 = IR[31:12];
+    logic [(`L2_REG_FILE_SIZE - 1):0] read_gpr_A_sel, read_gpr_B_sel;
+    logic [(`WORD_SIZE - 1):0]        read_gpr_A_data, read_gpr_B_data;
+    logic [(`INSTR_CODE_SIZE - 1):0]  decoded_instruction;
+    logic [(`WORD_SIZE - 1):0]        imm_1, imm_2;
+    logic [(`B_IMM_SIZE - 1):0]       imm_3_or_dest_addr;
 
-//Main state machine for the instruction execution cycle.
-always@(posedge clk)
-begin
-    case (current_state)
-    FETCH:;
-        //TODO: Implement Fetch From Wishbone 4 interface. Synchronous Mode.
-        //Illustration 4-2: WISHBONE Classic synchronous cycle terminated burst
-        //https://cdn.opencores.org/downloads/wbspec_b4.pdf
-        //Page: 66
+    /*
+     * decoder <-> register_file looks port-level circular (decoder's
+     * *_sel outputs feed regfile's read ports; regfile's read *_data
+     * outputs feed back into decoder's i_read_gpr_*_data inputs, which
+     * decoder uses to produce o_imm_1/o_imm_2) but it isn't a real
+     * combinational cycle: the *_sel outputs depend ONLY on
+     * i_instruction inside decoder, never on the data that comes back.
+     * It settles in zero simulated time as a plain feedforward chain.
+     */
+    decoder decoder0 (
+        .i_instruction(instruction),
+        .i_instruction_address(pc),
+        /*
+         * Explicitly connected to nothing (not omitted) -- it's just a
+         * passthrough of i_instruction_address (i.e. pc), nothing
+         * downstream needs a second copy of it. Empty parens rather than
+         * leaving the line out entirely so lint tools see this as
+         * deliberate rather than a possibly-forgotten connection.
+         */
+        /* verilator lint_off PINCONNECTEMPTY */
+        .o_instruction_address(),
+        /* verilator lint_on PINCONNECTEMPTY */
+        .o_read_gpr_A_sel(read_gpr_A_sel),
+        .i_read_gpr_A_data(read_gpr_A_data),
+        .o_read_gpr_B_sel(read_gpr_B_sel),
+        .i_read_gpr_B_data(read_gpr_B_data),
+        .o_decoded_instruction(decoded_instruction),
+        .o_imm_1(imm_1),
+        .o_imm_2(imm_2),
+        .o_imm_3_or_dest_addr(imm_3_or_dest_addr)
+    );
 
-    EXECUTE:;
-        //TODO: Implement ALU Execution
+    logic                       reg_write;
+    logic [(`WORD_SIZE - 1):0]  reg_write_data;
 
-        //TODO: Implement Memory Write
+    register_file regfile0 (
+        .i_clk(clk),
+        .i_read_gpr_A_sel(read_gpr_A_sel),
+        .o_read_gpr_A_data(read_gpr_A_data),
+        .i_read_gpr_B_sel(read_gpr_B_sel),
+        .o_read_gpr_B_data(read_gpr_B_data),
+        .i_load_gpr(reg_write),
+        /*
+         * imm_3_or_dest_addr means two unrelated things depending on
+         * instruction type (see decoder.sv's port doc for the full
+         * story): a signed S/B-type offset, or a plain 5-bit rd index
+         * (R/I/U/J-type). Here we use ONLY the low 5 bits, as an
+         * unsigned register index -- correct for the R/I/U/J case, and
+         * harmless for S/B-type (stores and branches never assert
+         * reg_write, so regfile0 ignores this value in that case
+         * regardless of what garbage sign bits sit above it). Getting
+         * this confused with the SIGNED interpretation (imm3_sext,
+         * below) is the single easiest mistake to make with this port --
+         * small positive immediates look identical either way, so a
+         * quick smoke test won't catch it, only a negative-offset test
+         * will (see core_load_store_tb.sv).
+         */
+        .i_load_gpr_sel(imm_3_or_dest_addr[(`L2_REG_FILE_SIZE - 1):0]),
+        .i_load_gpr_data(reg_write_data)
+    );
 
-        //TODO: Implement Memory Reads
+    /* Sign-extended S/B-type offset -- see the comment above. */
+    wire [(`WORD_SIZE - 1):0] imm3_sext =
+        {{(`WORD_SIZE - `B_IMM_SIZE){imm_3_or_dest_addr[`B_IMM_SIZE - 1]}}, imm_3_or_dest_addr};
 
-        //TODO: Implement Branch Instructions
+    /* --------------------------------------------------------------- *
+     * Control unit
+     * --------------------------------------------------------------- */
 
-        //NOTES: The state machine can have nested states to accommodate wishbone BUS logic.
+    wire is_auipc = (decoded_instruction == `INSTR_CODE(AUIPC));
+    wire is_jal   = (decoded_instruction == `INSTR_CODE(JAL));
+    wire is_jalr  = (decoded_instruction == `INSTR_CODE(JALR));
 
-    default:;
-    endcase
-end
+    /*
+     * ADDW/SUBW/ADDIW reuse the plain ADD/SUB ALU ops on full 64-bit
+     * operands (bit-identical to a native 32-bit add/sub in the low 32
+     * bits -- two's-complement addition is modular arithmetic) and get
+     * truncated+re-signed HERE, centrally, in the write-back mux below.
+     * SLLW/SRLW/SRAW(+I variants) can't take that shortcut -- a shift is
+     * NOT bit-identical across widths (wrong-width operand, bits enter
+     * from the wrong end) -- so those instead use dedicated 32-bit-wide
+     * ALU ops (see alu_ops.sv) whose output is already the final,
+     * correctly-extended 64-bit value; they fall through the write-back
+     * mux untouched, same as any ordinary ALU result.
+     */
+    wire is_word_arith = (decoded_instruction == `INSTR_CODE(ADDW))
+                       || (decoded_instruction == `INSTR_CODE(SUBW))
+                       || (decoded_instruction == `INSTR_CODE(ADDIW));
 
+    logic [(`ALU_OPSIZE - 1):0] alu_op;
+    always_comb begin: alu_op_sel
+        case (decoded_instruction)
+            `INSTR_CODE(ADDI), `INSTR_CODE(ADD),
+            `INSTR_CODE(ADDIW), `INSTR_CODE(ADDW),
+            /*
+             * Also every instruction that uses the ALU purely as an
+             * adder rather than for its "own" arithmetic meaning: LUI
+             * (o_imm_2=0 from the decoder, so ADD is a passthrough of
+             * o_imm_1), AUIPC (pc + immediate, via the operand-A mux
+             * below), JALR and every load/store (base + offset address
+             * calculation).
+             */
+            `INSTR_CODE(LUI), `INSTR_CODE(AUIPC), `INSTR_CODE(JALR),
+            `INSTR_CODE(LB), `INSTR_CODE(LH), `INSTR_CODE(LW),
+            `INSTR_CODE(LBU), `INSTR_CODE(LHU), `INSTR_CODE(LWU), `INSTR_CODE(LD),
+            `INSTR_CODE(SB), `INSTR_CODE(SH), `INSTR_CODE(SW), `INSTR_CODE(SD):
+                alu_op = `ADD;
+
+            `INSTR_CODE(SUB), `INSTR_CODE(SUBW):
+                alu_op = `SUB;
+
+            `INSTR_CODE(SLTI), `INSTR_CODE(SLT):   alu_op = `SLT;
+            `INSTR_CODE(SLTIU), `INSTR_CODE(SLTU): alu_op = `SLTU;
+            `INSTR_CODE(XORI), `INSTR_CODE(XOR):   alu_op = `XOR;
+            `INSTR_CODE(ORI), `INSTR_CODE(OR):     alu_op = `OR;
+            `INSTR_CODE(ANDI), `INSTR_CODE(AND):   alu_op = `AND;
+
+            `INSTR_CODE(SLLI), `INSTR_CODE(SLL): alu_op = `SLL;
+            `INSTR_CODE(SRLI), `INSTR_CODE(SRL): alu_op = `SRL;
+            `INSTR_CODE(SRAI), `INSTR_CODE(SRA): alu_op = `SRA;
+
+            `INSTR_CODE(SLLIW), `INSTR_CODE(SLLW): alu_op = `SLLW;
+            `INSTR_CODE(SRLIW), `INSTR_CODE(SRLW): alu_op = `SRLW;
+            `INSTR_CODE(SRAIW), `INSTR_CODE(SRAW): alu_op = `SRAW;
+
+            /*
+             * Branches/JAL/FENCE/ECALL/EBREAK/INVALID don't use
+             * alu_result for anything (branches have their own
+             * comparator below; JAL's target/link come from the PC
+             * adder and pc_plus_4 directly) -- alu_op is a don't-care
+             * for these, defaulted to ADD purely so alu_op always has a
+             * defined value.
+             */
+            default: alu_op = `ADD;
+        endcase
+    end: alu_op_sel
+
+    logic is_load, is_store;
+    logic [1:0] mem_size;
+    logic load_signed;
+    always_comb begin: mem_control
+        is_load = 1'b0;
+        is_store = 1'b0;
+        mem_size = 2'b10;
+        load_signed = 1'b0;
+        case (decoded_instruction)
+            `INSTR_CODE(LB):  begin is_load = 1'b1; mem_size = 2'b00; load_signed = 1'b1; end
+            `INSTR_CODE(LBU): begin is_load = 1'b1; mem_size = 2'b00; load_signed = 1'b0; end
+            `INSTR_CODE(LH):  begin is_load = 1'b1; mem_size = 2'b01; load_signed = 1'b1; end
+            `INSTR_CODE(LHU): begin is_load = 1'b1; mem_size = 2'b01; load_signed = 1'b0; end
+            `INSTR_CODE(LW):  begin is_load = 1'b1; mem_size = 2'b10; load_signed = 1'b1; end
+            `INSTR_CODE(LWU): begin is_load = 1'b1; mem_size = 2'b10; load_signed = 1'b0; end
+            `INSTR_CODE(LD):  begin is_load = 1'b1; mem_size = 2'b11; load_signed = 1'b1; end
+            `INSTR_CODE(SB):  begin is_store = 1'b1; mem_size = 2'b00; end
+            `INSTR_CODE(SH):  begin is_store = 1'b1; mem_size = 2'b01; end
+            `INSTR_CODE(SW):  begin is_store = 1'b1; mem_size = 2'b10; end
+            `INSTR_CODE(SD):  begin is_store = 1'b1; mem_size = 2'b11; end
+            default: ;
+        endcase
+    end: mem_control
+
+    /*
+     * reg_write: computed by excluding the SHORT list of instructions
+     * that don't write rd, rather than enumerating the long list that
+     * does -- fewer places to accidentally miss an entry when a future
+     * milestone adds more instructions.
+     */
+    logic reg_write_ctrl;
+    always_comb begin: reg_write_control
+        case (decoded_instruction)
+            `INSTR_CODE(SB), `INSTR_CODE(SH), `INSTR_CODE(SW), `INSTR_CODE(SD),
+            `INSTR_CODE(BEQ), `INSTR_CODE(BNE), `INSTR_CODE(BLT),
+            `INSTR_CODE(BGE), `INSTR_CODE(BLTU), `INSTR_CODE(BGEU),
+            `INSTR_CODE(FENCE), `INSTR_CODE(ECALL), `INSTR_CODE(EBREAK),
+            `INSTR_CODE(INVALID):
+                reg_write_ctrl = 1'b0;
+            default:
+                reg_write_ctrl = 1'b1;
+        endcase
+    end: reg_write_control
+    assign reg_write = reg_write_ctrl;
+
+    /* --------------------------------------------------------------- *
+     * Execute
+     * --------------------------------------------------------------- */
+
+    /*
+     * AUIPC needs pc+imm, but the decoder parks the U-immediate on
+     * o_imm_1 (the "A slot") for both LUI and AUIPC, with o_imm_2
+     * hardwired to 0 (OUTPUT_U_TYPE_INSTR). LUI rides that as-is: A =
+     * imm_1, B = imm_2 (0), giving imm+0. AUIPC instead needs pc as one
+     * addend and the immediate as the other, so it swaps BOTH operands:
+     * A becomes pc, and B is redirected to imm_1 to recover the
+     * immediate that A just displaced -- using the default imm_2 here
+     * (0) would silently compute pc+0 and drop the immediate entirely.
+     */
+    wire [(`WORD_SIZE - 1):0] alu_operand_a = is_auipc ? pc : imm_1;
+    wire [(`WORD_SIZE - 1):0] alu_operand_b = is_store  ? imm3_sext :
+                                                is_auipc  ? imm_1     :
+                                                             imm_2;
+
+    logic [(`WORD_SIZE - 1):0] alu_result;
+    alu alu0 (
+        .i_operand_A(alu_operand_a),
+        .i_operation(alu_op),
+        .i_operand_B(alu_operand_b),
+        .o_result(alu_result)
+    );
+
+    /*
+     * Branch comparator: NOT routed through alu0. alu_ops.sv has no
+     * equality/inequality op, and each branch type needs a different
+     * comparison (equality, signed, unsigned) -- easier as its own small
+     * block than trying to force it through a shared single-op ALU
+     * interface. default: 1'b0 doubles as "this instruction isn't a
+     * branch at all", so the next-PC mux below needs no separate
+     * is_branch gate.
+     */
+    logic take_branch;
+    always_comb begin: branch_comparator
+        case (decoded_instruction)
+            `INSTR_CODE(BEQ):  take_branch = (imm_1 == imm_2);
+            `INSTR_CODE(BNE):  take_branch = (imm_1 != imm_2);
+            `INSTR_CODE(BLT):  take_branch = ($signed(imm_1) <  $signed(imm_2));
+            `INSTR_CODE(BGE):  take_branch = ($signed(imm_1) >= $signed(imm_2));
+            `INSTR_CODE(BLTU): take_branch = (imm_1 < imm_2);
+            `INSTR_CODE(BGEU): take_branch = (imm_1 >= imm_2);
+            default:           take_branch = 1'b0;
+        endcase
+    end: branch_comparator
+
+    /* --------------------------------------------------------------- *
+     * Memory
+     * --------------------------------------------------------------- */
+
+    /*
+     * alu_result does double duty here: it's "the ALU's answer" for
+     * every non-memory instruction, and "the memory address" for
+     * loads/stores (base register + offset, computed by the same adder
+     * via the operand muxing above) -- deliberate reuse of one datapath,
+     * not a coincidence.
+     */
+    logic [(`WORD_SIZE - 1):0] dmem_rdata;
+    dmem dmem0 (
+        .i_clk(clk),
+        .i_addr(alu_result),
+        .i_size(mem_size),
+        .i_write_enable(is_store),
+        .i_write_data(imm_2),  // rs2 -- OUTPUT_S_TYPE_INSTR puts the store's source value here
+        .o_read_data(dmem_rdata)
+    );
+
+    /* Shift dmem's line so the byte(s) we actually want start at bit 0. */
+    wire [(`WORD_SIZE - 1):0] dmem_rdata_shifted = dmem_rdata >> (alu_result[2:0] * 8);
+
+    /*
+     * Precomputed slices, not inline inside load_format's case statement
+     * below -- Icarus Verilog doesn't fully support constant selects
+     * inside always_* processes (same reason as alu.sv's shamt_masked).
+     */
+    wire [7:0]  load_byte  = dmem_rdata_shifted[7:0];
+    wire [15:0] load_half  = dmem_rdata_shifted[15:0];
+    wire [31:0] load_word  = dmem_rdata_shifted[31:0];
+    /* Sign bits, precomputed too -- same reason (also used inside a replication below). */
+    wire load_byte_sign = load_byte[7];
+    wire load_half_sign = load_half[15];
+    wire load_word_sign = load_word[31];
+
+    logic [(`WORD_SIZE - 1):0] load_data;
+    always_comb begin: load_format
+        case (mem_size)
+            2'b00: load_data = load_signed ? {{56{load_byte_sign}}, load_byte}
+                                            : {56'b0, load_byte};
+            2'b01: load_data = load_signed ? {{48{load_half_sign}}, load_half}
+                                            : {48'b0, load_half};
+            2'b10: load_data = load_signed ? {{32{load_word_sign}}, load_word}
+                                            : {32'b0, load_word};
+            default: load_data = dmem_rdata_shifted; // 2'b11: doubleword, no extension needed
+        endcase
+    end: load_format
+
+    /* --------------------------------------------------------------- *
+     * Writeback
+     * --------------------------------------------------------------- */
+
+    wire [(`WORD_SIZE - 1):0] pc_plus_4 = pc + `WORD_SIZE'(4);
+
+    /* See the is_word_arith comment above for why only some *W ops need this. */
+    wire [(`WORD_SIZE - 1):0] alu_result_w_trunc = {{32{alu_result[31]}}, alu_result[31:0]};
+
+    assign reg_write_data = is_load               ? load_data :
+                             (is_jal || is_jalr)   ? pc_plus_4 :
+                             is_word_arith         ? alu_result_w_trunc :
+                                                      alu_result; // ALU ops, LUI, AUIPC, *W shifts
+
+    /* --------------------------------------------------------------- *
+     * Next PC
+     * --------------------------------------------------------------- */
+
+    /* JAL's immediate lands on imm_1 (OUTPUT_J_TYPE_INSTR); branches' on imm3_sext. */
+    wire [(`WORD_SIZE - 1):0] pc_rel_offset = is_jal ? imm_1 : imm3_sext;
+    wire [(`WORD_SIZE - 1):0] pc_rel_target = pc + pc_rel_offset;
+
+    /*
+     * Per spec, JALR's target is (rs1 + sext(imm)) with bit 0 forced to
+     * 0 -- guarantees an even target regardless of whether rs1+imm
+     * happens to be odd. Only the JUMP TARGET's LSB is cleared here; the
+     * link value written back to rd (pc_plus_4, above) is always
+     * unmodified.
+     */
+    wire [(`WORD_SIZE - 1):0] jalr_target = {alu_result[63:1], 1'b0};
+
+    assign next_pc = (is_jal || take_branch) ? pc_rel_target :
+                      is_jalr                 ? jalr_target   :
+                                                 pc_plus_4;
+
+    /* --------------------------------------------------------------- *
+     * PC register / halt latch
+     * --------------------------------------------------------------- */
+
+    /*
+     * EBREAK latches `halted` and freezes pc -- the only piece of
+     * "extra" state in this design, beyond pc itself and the two
+     * memories' write ports. Freezing pc (rather than letting it run on
+     * into whatever follows EBREAK) is a deliberate choice: once
+     * halted, the core would otherwise keep fetching and "executing"
+     * subsequent memory contents, which is harmless if that's zeroed
+     * (decodes as INVALID, a no-op) but isn't guaranteed to be zero in
+     * every testbench. Testbenches watch this signal via a hierarchical
+     * reference (e.g. dut.halted) to know when a test program has
+     * finished running, without guessing a cycle count.
+     */
+    logic halted;
+    always_ff @(posedge clk) begin
+        if (rst)
+            halted <= 1'b0;
+        else if (decoded_instruction == `INSTR_CODE(EBREAK))
+            halted <= 1'b1;
+    end
+
+    always_ff @(posedge clk) begin
+        pc <= rst ? '0 : (halted ? pc : next_pc);
+    end
 
 endmodule

--- a/design/decoder.sv
+++ b/design/decoder.sv
@@ -30,73 +30,130 @@
  * please modify these macros appropriately.
  */
 
+/*
+ * NB: these use blocking (=) assignment throughout, matching the
+ * always_comb block they're used inside (detect_and_assign, below) --
+ * non-blocking (<=) inside always_comb is non-idiomatic and both iverilog
+ * and verilator flag it (verilator: COMBDLY). Icarus tolerates it and
+ * simulates it correctly, but there's no reason to rely on that leniency.
+ *
+ * Also NB: `B_IMM_SIZE'(destination) below is an explicit width cast, not
+ * a stylistic flourish -- destination is 5 bits (DEST_SIZE) and
+ * o_imm_3_or_dest_addr is 13 (B_IMM_SIZE); the implicit zero-extension is
+ * correct (a register index is unsigned) but verilator's -Wall flags the
+ * implicit width change, so it's made explicit rather than left as a
+ * warning to re-triage every time this file is linted.
+ */
+
 `define PASS_REG_A_IN_IMM_1(reg_addr)   \
-    o_read_gpr_A_sel <= reg_addr;       \
-    internal_imm_1 <= 0;                \
+    o_read_gpr_A_sel = reg_addr;        \
+    internal_imm_1 = 0;                 \
 ;
 
 `define PASS_REG_B_IN_IMM_2(reg_addr)   \
-    o_read_gpr_B_sel <= reg_addr;       \
-    internal_imm_2 <= 0;                \
+    o_read_gpr_B_sel = reg_addr;        \
+    internal_imm_2 = 0;                 \
 ;
 
 `define PASS_IMM_IN_IMM_1(imm)  \
-    o_read_gpr_A_sel <= 0;      \
-    internal_imm_1 <= imm;      \
+    o_read_gpr_A_sel = 0;       \
+    internal_imm_1 = imm;       \
 ;
 
 `define PASS_IMM_IN_IMM_2(imm)  \
-    o_read_gpr_B_sel <= 0;      \
-    internal_imm_2 <= imm;      \
+    o_read_gpr_B_sel = 0;       \
+    internal_imm_2 = imm;       \
 ;
 
 `define OUTPUT_R_TYPE_INSTR(instr_name)                 \
-    o_decoded_instruction <= `INSTR_CODE(instr_name);   \
-    `PASS_REG_A_IN_IMM_1(source_1);                     \
-    `PASS_REG_B_IN_IMM_2(source_2);                     \
-    o_imm_3_or_dest_addr <= destination;                \
+    o_decoded_instruction = `INSTR_CODE(instr_name);    \
+    `PASS_REG_A_IN_IMM_1(source_1);                      \
+    `PASS_REG_B_IN_IMM_2(source_2);                      \
+    o_imm_3_or_dest_addr = `B_IMM_SIZE'(destination);   \
 ;
 
+/*
+ * I-type, general (ADDI/SLTI/.../loads/JALR/ADDIW): imm_i_sext is the
+ * 12-bit I-immediate, sign-extended to WORD_SIZE. NOT used for the
+ * shift-immediate instructions (SLLI/SRLI/SRAI/SLLIW/SRLIW/SRAIW) -- see
+ * OUTPUT_I_SHIFT_TYPE_INSTR/OUTPUT_IW_SHIFT_TYPE_INSTR below, since a
+ * shift amount is an unsigned magnitude occupying only part of this same
+ * field, not a sign-extended value occupying all of it.
+ */
 `define OUTPUT_I_TYPE_INSTR(instr_name)                 \
-    o_decoded_instruction <= `INSTR_CODE(instr_name);   \
-    `PASS_REG_A_IN_IMM_1(source_1);                     \
-    `PASS_IMM_IN_IMM_2(imm_i);                          \
-    o_imm_3_or_dest_addr <= destination;                \
+    o_decoded_instruction = `INSTR_CODE(instr_name);    \
+    `PASS_REG_A_IN_IMM_1(source_1);                      \
+    `PASS_IMM_IN_IMM_2(imm_i_sext);                      \
+    o_imm_3_or_dest_addr = `B_IMM_SIZE'(destination);   \
 ;
 
+/*
+ * I-type, shift-immediate (SLLI/SRLI/SRAI): shamt_zext is just the 6-bit
+ * shift-amount field, ZERO-extended (a shift amount is a magnitude, never
+ * sign-extended) -- NOT the generic imm_i_sext, which would incorrectly
+ * carry the instruction's funct6 bits along as if they were part of a
+ * signed immediate.
+ */
+`define OUTPUT_I_SHIFT_TYPE_INSTR(instr_name)            \
+    o_decoded_instruction = `INSTR_CODE(instr_name);     \
+    `PASS_REG_A_IN_IMM_1(source_1);                       \
+    `PASS_IMM_IN_IMM_2(shamt_zext);                       \
+    o_imm_3_or_dest_addr = `B_IMM_SIZE'(destination);     \
+;
+
+/*
+ * I-type, RV64I word-shift-immediate (SLLIW/SRLIW/SRAIW): same idea as
+ * OUTPUT_I_SHIFT_TYPE_INSTR, but the shift amount is only 5 bits wide
+ * here (word-shifts are always 32-bit, so 5 bits is always enough) --
+ * see wshamt_zext.
+ */
+`define OUTPUT_IW_SHIFT_TYPE_INSTR(instr_name)           \
+    o_decoded_instruction = `INSTR_CODE(instr_name);     \
+    `PASS_REG_A_IN_IMM_1(source_1);                       \
+    `PASS_IMM_IN_IMM_2(wshamt_zext);                      \
+    o_imm_3_or_dest_addr = `B_IMM_SIZE'(destination);     \
+;
+
+/*
+ * S-type (stores): imm_s is declared WIDER than its natural 12 bits (see
+ * its declaration below) specifically so it already carries a correct
+ * sign bit at the same position B-type's imm_b does -- no separate _sext
+ * variant needed here, imm_s IS the port-ready, already-sign-extended-by-
+ * construction value.
+ */
 `define OUTPUT_S_TYPE_INSTR(instr_name)                 \
-    o_decoded_instruction <= `INSTR_CODE(instr_name);   \
-    `PASS_REG_A_IN_IMM_1(source_1);                     \
-    `PASS_REG_B_IN_IMM_2(source_2);                     \
-    o_imm_3_or_dest_addr <= imm_s;                      \
+    o_decoded_instruction = `INSTR_CODE(instr_name);    \
+    `PASS_REG_A_IN_IMM_1(source_1);                      \
+    `PASS_REG_B_IN_IMM_2(source_2);                      \
+    o_imm_3_or_dest_addr = imm_s;                        \
 ;
 
 `define OUTPUT_B_TYPE_INSTR(instr_name)                 \
-    o_decoded_instruction <= `INSTR_CODE(instr_name);   \
-    `PASS_REG_A_IN_IMM_1(source_1);                     \
-    `PASS_REG_B_IN_IMM_2(source_2);                     \
-    o_imm_3_or_dest_addr <= imm_b;                      \
+    o_decoded_instruction = `INSTR_CODE(instr_name);    \
+    `PASS_REG_A_IN_IMM_1(source_1);                      \
+    `PASS_REG_B_IN_IMM_2(source_2);                      \
+    o_imm_3_or_dest_addr = imm_b;                        \
 ;
 
 `define OUTPUT_U_TYPE_INSTR(instr_name)                 \
-    o_decoded_instruction <= `INSTR_CODE(instr_name);   \
-    `PASS_IMM_IN_IMM_1(imm_u);                          \
-    `PASS_IMM_IN_IMM_2(0);                              \
-    o_imm_3_or_dest_addr <= destination;                \
+    o_decoded_instruction = `INSTR_CODE(instr_name);    \
+    `PASS_IMM_IN_IMM_1(imm_u_sext);                      \
+    `PASS_IMM_IN_IMM_2(0);                               \
+    o_imm_3_or_dest_addr = `B_IMM_SIZE'(destination);   \
 ;
 
 `define OUTPUT_J_TYPE_INSTR(instr_name)                 \
-    o_decoded_instruction <= `INSTR_CODE(instr_name);   \
-    `PASS_IMM_IN_IMM_1(imm_j);                          \
-    `PASS_IMM_IN_IMM_2(0);                              \
-    o_imm_3_or_dest_addr <= destination;                \
+    o_decoded_instruction = `INSTR_CODE(instr_name);    \
+    `PASS_IMM_IN_IMM_1(imm_j_sext);                      \
+    `PASS_IMM_IN_IMM_2(0);                               \
+    o_imm_3_or_dest_addr = `B_IMM_SIZE'(destination);   \
 ;
 
 `define OUTPUT_NONE_TYPE_INSTR(instr_name)              \
-    o_decoded_instruction <= `INSTR_CODE(instr_name);   \
-    `PASS_IMM_IN_IMM_1(0);                              \
-    `PASS_IMM_IN_IMM_2(0);                              \
-    o_imm_3_or_dest_addr <= 0;                          \
+    o_decoded_instruction = `INSTR_CODE(instr_name);    \
+    `PASS_IMM_IN_IMM_1(0);                               \
+    `PASS_IMM_IN_IMM_2(0);                               \
+    o_imm_3_or_dest_addr = 0;                            \
 ;
 
 
@@ -120,12 +177,23 @@
  *  o_decoded_instruction: The internal code for the decoded instruction.
  *  o_instruction_address: Address of the decoded instruction
  *                         (same as i_instruction_address).
- *  o_imm_1: Immediate value (either from instr or from a reg), or 0.
- *  o_imm_2: Immediate value (either from instr or from a reg), or 0.
- *  o_imm_3_or_dest_addr: For S and B type insturctions, this is the given
- *                        immediate value. For most other instructions, it
- *                        is the address to the destination register. It is
- *                        0 otherwise.
+ *  o_imm_1: Immediate value (either from instr or from a reg), or 0. Any
+ *           immediate here is already sign- or zero-extended to
+ *           WORD_SIZE as appropriate (sign-extended for ordinary
+ *           immediates, zero-extended for shift amounts -- see
+ *           shamt_zext/wshamt_zext below).
+ *  o_imm_2: Same as o_imm_1, for the second operand slot.
+ *  o_imm_3_or_dest_addr: For S and B type instructions, this is the
+ *                        immediate value -- 13 bits (B_IMM_SIZE), with
+ *                        the sign bit always at bit 12 regardless of
+ *                        which of the two types it came from (see imm_s's
+ *                        declaration below for why S-type needs an extra
+ *                        bit to make that true). For most other
+ *                        instructions, it is the destination register
+ *                        index (5 bits, zero-extended into the same
+ *                        13-bit port). 0 otherwise. Sign/zero-extending
+ *                        this further to WORD_SIZE, when needed, is
+ *                        core.sv's job, not the decoder's.
  */
 module decoder (
     input logic     [(`INSTR_SIZE - 1):0]   i_instruction,
@@ -163,8 +231,15 @@ module decoder (
 
     logic [(`WORD_SIZE - 1):0] internal_imm_1;
     logic [(`WORD_SIZE - 1):0] internal_imm_2;
-    assign o_imm_1 = o_read_gpr_A_sel ? i_read_gpr_A_data : internal_imm_1;
-    assign o_imm_2 = o_read_gpr_B_sel ? i_read_gpr_B_data : internal_imm_2;
+    /*
+     * != 0 here (rather than relying on o_read_gpr_A_sel's truth value
+     * directly) is explicit about this being a "is this the x0 sentinel"
+     * check, not an arithmetic use of the select value -- also avoids a
+     * multi-bit-to-1-bit implicit truthiness cast that verilator flags
+     * under -Wall (WIDTHTRUNC).
+     */
+    assign o_imm_1 = (o_read_gpr_A_sel != 0) ? i_read_gpr_A_data : internal_imm_1;
+    assign o_imm_2 = (o_read_gpr_B_sel != 0) ? i_read_gpr_B_data : internal_imm_2;
 
     /*
      * Extract potential constituents from the instruction beforehand
@@ -183,8 +258,27 @@ module decoder (
     logic [(`I_IMM_SIZE - 1):0] imm_i;
     assign imm_i = i_instruction[`I_IMM_MSB:`I_IMM_LSB];
 
-    logic [(`S_IMM_SIZE - 1):0] imm_s;
-    assign imm_s = {i_instruction[`S_IMM_H_MSB:`S_IMM_H_LSB],
+    /* imm_i, sign-extended: bit 11 (imm_i's own MSB) is the sign bit. */
+    logic [(`WORD_SIZE - 1):0] imm_i_sext;
+    assign imm_i_sext = {{(`WORD_SIZE - `I_IMM_SIZE){imm_i[`I_IMM_SIZE - 1]}}, imm_i};
+
+    /*
+     * imm_s is deliberately declared B_IMM_SIZE (13) bits wide, not its
+     * "natural" 12 -- one bit wider than the raw S-immediate field, with
+     * the extra top bit an explicit copy of the sign bit (instruction bit
+     * 31, same sign-bit position I/S/B all share). This puts imm_s's sign
+     * bit at position 12, the SAME position imm_b's sign bit naturally
+     * lands at (see imm_b below) -- so o_imm_3_or_dest_addr (which is
+     * B_IMM_SIZE wide and carries either of these two, depending on
+     * instruction type) can be sign-extended by core.sv with a single
+     * formula that works for both S and B types, instead of two.
+     * Without this, assigning the narrower 12-bit imm_s into that 13-bit
+     * port would implicitly ZERO-pad bit 12, silently making every store
+     * offset read as non-negative downstream regardless of its true sign.
+     */
+    logic [(`B_IMM_SIZE - 1):0] imm_s;
+    assign imm_s = {i_instruction[`S_IMM_H_MSB],
+                    i_instruction[`S_IMM_H_MSB:`S_IMM_H_LSB],
                     i_instruction[`S_IMM_L_MSB:`S_IMM_L_LSB]};
 
     logic [(`B_IMM_SIZE - 1):0] imm_b;
@@ -199,6 +293,17 @@ module decoder (
     logic [(`U_IMM_SIZE - 1):0] imm_u;
     assign imm_u = i_instruction[`U_IMM_MSB:`U_IMM_LSB];
 
+    /*
+     * imm_u, turned into the actual usable upper-immediate value: LUI/
+     * AUIPC's 20-bit field is bits [31:12] of the result, not the low 20
+     * bits -- shift it into place, THEN sign-extend the resulting 32-bit
+     * value out to WORD_SIZE using what is now bit 31 (= imm_u's own bit
+     * 19, the field's original top bit). Without the shift, LUI/AUIPC
+     * would be numerically wrong even before considering sign at all.
+     */
+    logic [(`WORD_SIZE - 1):0] imm_u_sext;
+    assign imm_u_sext = {{(`WORD_SIZE - 32){imm_u[`U_IMM_SIZE - 1]}}, imm_u, 12'b0};
+
     logic [(`J_IMM_SIZE - 1):0] imm_j;
     assign imm_j = {
         i_instruction[`J_IMM_MSB],
@@ -207,6 +312,26 @@ module decoder (
         i_instruction[`J_IMM_LOW_BITS_MSB:`J_IMM_LOW_BITS_LSB],
         1'b0
     };
+
+    /* imm_j, sign-extended: bit 20 (imm_j's own MSB) is the sign bit. */
+    logic [(`WORD_SIZE - 1):0] imm_j_sext;
+    assign imm_j_sext = {{(`WORD_SIZE - `J_IMM_SIZE){imm_j[`J_IMM_SIZE - 1]}}, imm_j};
+
+    /*
+     * Shift amounts: extracted separately from imm_i on purpose (see
+     * OUTPUT_I_SHIFT_TYPE_INSTR/OUTPUT_IW_SHIFT_TYPE_INSTR above) and
+     * ZERO-, not sign-, extended -- a shift amount is an unsigned
+     * magnitude, not a two's-complement value.
+     */
+    logic [(`SHAMT_SIZE - 1):0] shamt;
+    assign shamt = i_instruction[`SHAMT_MSB:`SHAMT_LSB];
+    logic [(`WORD_SIZE - 1):0] shamt_zext;
+    assign shamt_zext = {{(`WORD_SIZE - `SHAMT_SIZE){1'b0}}, shamt};
+
+    logic [(`WSHAMT_SIZE - 1):0] wshamt;
+    assign wshamt = i_instruction[`WSHAMT_MSB:`WSHAMT_LSB];
+    logic [(`WORD_SIZE - 1):0] wshamt_zext;
+    assign wshamt_zext = {{(`WORD_SIZE - `WSHAMT_SIZE){1'b0}}, wshamt};
 
 
     /* Match the instruction and do appropriate decoding. */
@@ -308,6 +433,19 @@ module decoder (
         end: lhu_instr
 
 
+        /* RV64I-only loads. */
+
+
+        else if (`IS_INSTR(i_instruction, LWU)) begin: lwu_instr
+            `OUTPUT_I_TYPE_INSTR(LWU);
+        end: lwu_instr
+
+
+        else if (`IS_INSTR(i_instruction, LD)) begin: ld_instr
+            `OUTPUT_I_TYPE_INSTR(LD);
+        end: ld_instr
+
+
         /* --------------------------------------------------------- */
 
 
@@ -327,6 +465,14 @@ module decoder (
         else if (`IS_INSTR(i_instruction, SW)) begin: sw_instr
             `OUTPUT_S_TYPE_INSTR(SW);
         end: sw_instr
+
+
+        /* RV64I-only store. */
+
+
+        else if (`IS_INSTR(i_instruction, SD)) begin: sd_instr
+            `OUTPUT_S_TYPE_INSTR(SD);
+        end: sd_instr
 
 
         /* --------------------------------------------------------- */
@@ -401,7 +547,7 @@ module decoder (
 
 
         else if (`IS_INSTR(i_instruction, SLLI)) begin: slli_instr
-            `OUTPUT_I_TYPE_INSTR(SLLI);
+            `OUTPUT_I_SHIFT_TYPE_INSTR(SLLI);
         end: slli_instr
 
 
@@ -411,7 +557,7 @@ module decoder (
 
 
         else if (`IS_INSTR(i_instruction, SRLI)) begin: srli_instr
-            `OUTPUT_I_TYPE_INSTR(SRLI);
+            `OUTPUT_I_SHIFT_TYPE_INSTR(SRLI);
         end: srli_instr
 
 
@@ -421,13 +567,72 @@ module decoder (
 
 
         else if (`IS_INSTR(i_instruction, SRAI)) begin: srai_instr
-            `OUTPUT_I_TYPE_INSTR(SRAI);
+            `OUTPUT_I_SHIFT_TYPE_INSTR(SRAI);
         end: srai_instr
 
 
         else if (`IS_INSTR(i_instruction, SRA)) begin: sra_instr
             `OUTPUT_R_TYPE_INSTR(SRA);
         end: sra_instr
+
+
+        /* --------------------------------------------------------- */
+
+
+        /*
+         * RV64I word-width instructions: operate on the low 32 bits of
+         * their operands and sign-extend the result back to 64 -- see
+         * the comment above SLLW/SRLW/SRAW's `defines in
+         * defaults/alu_ops.sv for why the shift variants need dedicated
+         * ALU ops rather than reusing SLL/SRL/SRA, and the comment on
+         * `is_word_arith`-style write-back muxing (in core.sv) for why
+         * ADDW/SUBW/ADDIW instead reuse the plain ADD/SUB ALU ops.
+         */
+
+
+        else if (`IS_INSTR(i_instruction, ADDIW)) begin: addiw_instr
+            `OUTPUT_I_TYPE_INSTR(ADDIW);
+        end: addiw_instr
+
+
+        else if (`IS_INSTR(i_instruction, SLLIW)) begin: slliw_instr
+            `OUTPUT_IW_SHIFT_TYPE_INSTR(SLLIW);
+        end: slliw_instr
+
+
+        else if (`IS_INSTR(i_instruction, SRLIW)) begin: srliw_instr
+            `OUTPUT_IW_SHIFT_TYPE_INSTR(SRLIW);
+        end: srliw_instr
+
+
+        else if (`IS_INSTR(i_instruction, SRAIW)) begin: sraiw_instr
+            `OUTPUT_IW_SHIFT_TYPE_INSTR(SRAIW);
+        end: sraiw_instr
+
+
+        else if (`IS_INSTR(i_instruction, ADDW)) begin: addw_instr
+            `OUTPUT_R_TYPE_INSTR(ADDW);
+        end: addw_instr
+
+
+        else if (`IS_INSTR(i_instruction, SUBW)) begin: subw_instr
+            `OUTPUT_R_TYPE_INSTR(SUBW);
+        end: subw_instr
+
+
+        else if (`IS_INSTR(i_instruction, SLLW)) begin: sllw_instr
+            `OUTPUT_R_TYPE_INSTR(SLLW);
+        end: sllw_instr
+
+
+        else if (`IS_INSTR(i_instruction, SRLW)) begin: srlw_instr
+            `OUTPUT_R_TYPE_INSTR(SRLW);
+        end: srlw_instr
+
+
+        else if (`IS_INSTR(i_instruction, SRAW)) begin: sraw_instr
+            `OUTPUT_R_TYPE_INSTR(SRAW);
+        end: sraw_instr
 
 
         /* --------------------------------------------------------- */

--- a/design/defaults/alu_ops.sv
+++ b/design/defaults/alu_ops.sv
@@ -6,7 +6,7 @@
 /* ------------------------------------------------------------------------- */
 
 
-`define ALU_OPSIZE 4    /* Since we have 10 ops, we need 4 bits. */
+`define ALU_OPSIZE 4    /* Since we have 14 ops, we need 4 bits. */
 
 
 /* ------------------------------------------------------------------------- */
@@ -35,6 +35,28 @@
 /* Custom instructions. */
 
 `define NOT     4'b1010     /* Bitwise NOT / inversion */
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * RV64I word ops (operate on the low 32 bits of the operands, shift amount
+ * is always 5 bits regardless of WORD_SIZE, result is sign-extended back to
+ * WORD_SIZE bits).
+ *
+ * These can NOT be synthesized by truncating SLL/SRL/SRA's 64-bit result:
+ * unlike add/sub, a shift is not width-agnostic -- shifting a 64-bit operand
+ * by a 6-bit amount and then truncating to 32 bits gives a different answer
+ * than shifting a 32-bit operand by a 5-bit amount (bits enter/exit from the
+ * wrong end once the shift amount's bit 5 differs, and bits above 31 that
+ * shouldn't participate at all can leak into the low 32 via SLL). So these
+ * get their own dedicated ops instead of reusing SLL/SRL/SRA.
+ */
+
+`define SLLW    4'b1011     /* Shift left word: (A[31:0] << B[4:0]), sign-extended */
+`define SRLW    4'b1100     /* Shift right word logical: (A[31:0] >> B[4:0]), sign-extended */
+`define SRAW    4'b1101     /* Shift right word arithmetic: (A[31:0] >>> B[4:0]), sign-extended */
 
 
 /* ------------------------------------------------------------------------- */

--- a/design/defaults/defaults.sv
+++ b/design/defaults/defaults.sv
@@ -9,8 +9,8 @@
  * Word size for the processor.
  * This also defines the register file width, bus width, etc.
  */
-`define WORD_SIZE       32
-`define L2_WORD_SIZE    5   /* log2(WORD_SIZE) = Number of bits. */
+`define WORD_SIZE       64
+`define L2_WORD_SIZE    6   /* log2(WORD_SIZE) = Number of bits. */
 
 
 /* Number of registers (as in x0-x31) in the register file. */

--- a/design/defaults/instruction_codes.sv
+++ b/design/defaults/instruction_codes.sv
@@ -119,4 +119,25 @@
 /* ------------------------------------------------------------------------- */
 
 
+/* RV64I-only instructions. */
+
+`define INSTR_CODE_LWU      101001
+`define INSTR_CODE_LD       101010
+`define INSTR_CODE_SD       101011
+
+`define INSTR_CODE_ADDIW    101100
+`define INSTR_CODE_SLLIW    101101
+`define INSTR_CODE_SRLIW    101110
+`define INSTR_CODE_SRAIW    101111
+
+`define INSTR_CODE_ADDW     110000
+`define INSTR_CODE_SUBW     110001
+`define INSTR_CODE_SLLW     110010
+`define INSTR_CODE_SRLW     110011
+`define INSTR_CODE_SRAW     110100
+
+
+/* ------------------------------------------------------------------------- */
+
+
 /* End of file. */

--- a/design/defaults/instruction_format.sv
+++ b/design/defaults/instruction_format.sv
@@ -50,6 +50,30 @@
 `define I_IMM_LSB   20
 
 
+/*
+ * Shift amount fields. These overlap the I-immediate's bit range but are
+ * NOT sign-extended like a normal I-immediate -- a shift amount is an
+ * unsigned magnitude, and under RV64I only its low bits are meaningful
+ * (the rest of what would be the I-immediate field is funct6/funct7,
+ * fixed by the instruction's mask/pattern, not part of the shift amount).
+ *
+ * SHAMT (6 bits, instr[25:20]): SLLI/SRLI/SRAI -- full WORD_SIZE shifts,
+ * so the amount needs enough bits for log2(64)=6.
+ *
+ * WSHAMT (5 bits, instr[24:20]): SLLIW/SRLIW/SRAIW -- these are always
+ * 32-bit operations regardless of WORD_SIZE, so 5 bits (log2(32)) is
+ * always enough, and bit 25 belongs to funct7 for these instead.
+ */
+
+`define SHAMT_SIZE  6
+`define SHAMT_MSB   25
+`define SHAMT_LSB   20
+
+`define WSHAMT_SIZE 5
+`define WSHAMT_MSB  24
+`define WSHAMT_LSB  20
+
+
 /* ------------------------------------------------------------------------- */
 
 

--- a/design/defaults/instructions_and_masks.sv
+++ b/design/defaults/instructions_and_masks.sv
@@ -84,6 +84,14 @@
 `define INSTR_LHU       `LOAD_INSTR_CREATE(3'b101)
 `define INSTR_MASK_LHU  `LOAD_INSTRS_MASK
 
+/* RV64I: 32-bit load, zero-extended (LW sign-extends; this doesn't). */
+`define INSTR_LWU       `LOAD_INSTR_CREATE(3'b110)
+`define INSTR_MASK_LWU  `LOAD_INSTRS_MASK
+
+/* RV64I: full 64-bit (doubleword) load. */
+`define INSTR_LD        `LOAD_INSTR_CREATE(3'b011)
+`define INSTR_MASK_LD   `LOAD_INSTRS_MASK
+
 
 /* ------------------------------------------------------------------------- */
 
@@ -102,6 +110,10 @@
 
 `define INSTR_SW        `STORE_INSTR_CREATE(3'b010)
 `define INSTR_MASK_SW   `STORE_INSTRS_MASK
+
+/* RV64I: full 64-bit (doubleword) store. */
+`define INSTR_SD        `STORE_INSTR_CREATE(3'b011)
+`define INSTR_MASK_SD   `STORE_INSTRS_MASK
 
 
 /* ------------------------------------------------------------------------- */
@@ -138,7 +150,18 @@
 
 `define IMM_SHIFT_INSTR_CREATE(bit30, funct3) \
                                {1'b0, bit30, 15'b0, funct3, 5'b0, 7'b0010011}
-`define IMM_SHIFT_INSTRS_MASK   {7'b1111111, 10'b0, 3'b111, 5'b0, 7'b1111111}
+/*
+ * RV64I widens the shift amount from 5 to 6 bits (log2(64) instead of
+ * log2(32)) -- bit 25, which used to be a fixed part of a 7-bit funct7,
+ * becomes shamt's top bit instead. So only funct6 (bits 31:26, 6 bits) is
+ * checked as a fixed pattern now; bit 25 must be a don't-care alongside
+ * the rest of the shamt field, not forced to 0 -- otherwise any shift
+ * amount of 32 or more (which sets bit 25/shamt[5]) would fail to match
+ * SLLI/SRLI/SRAI at all. IMM_SHIFT_INSTR_CREATE itself is unchanged: its
+ * "15'b0" block already covers bit 25 with a 0 that's now simply ignored
+ * (mask=0 there) rather than enforced.
+ */
+`define IMM_SHIFT_INSTRS_MASK   {6'b111111, 11'b0, 3'b111, 5'b0, 7'b1111111}
 
 `define INSTR_SLLI      `IMM_SHIFT_INSTR_CREATE(1'b0, 3'b001)
 `define INSTR_MASK_SLLI `IMM_SHIFT_INSTRS_MASK
@@ -148,6 +171,40 @@
 
 `define INSTR_SRAI      `IMM_SHIFT_INSTR_CREATE(1'b1, 3'b101)
 `define INSTR_MASK_SRAI `IMM_SHIFT_INSTRS_MASK
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * RV64I word-width immediate instructions (opcode 0011011): ADDIW is a
+ * plain I-type op, identical in shape to the IMM_AL family above just at
+ * a different opcode. SLLIW/SRLIW/SRAIW keep a 5-bit shamt (word-shifts
+ * are always 32-bit, regardless of WORD_SIZE) so, unlike the base shifts
+ * above, their funct7 stays a full 7 fixed bits -- same shape as the
+ * ORIGINAL (RV32I) IMM_SHIFT_INSTR_CREATE, just re-targeted to this
+ * opcode.
+ */
+
+`define IMM_AL32_INSTR_CREATE(funct3) {17'b0, funct3, 5'b0, 7'b0011011}
+`define IMM_AL32_INSTRS_MASK          {17'b0, 3'b111, 5'b0, 7'b1111111}
+
+`define INSTR_ADDIW         `IMM_AL32_INSTR_CREATE(3'b000)
+`define INSTR_MASK_ADDIW    `IMM_AL32_INSTRS_MASK
+
+
+`define IMM_SHIFT32_INSTR_CREATE(bit30, funct3) \
+                               {1'b0, bit30, 15'b0, funct3, 5'b0, 7'b0011011}
+`define IMM_SHIFT32_INSTRS_MASK   {7'b1111111, 10'b0, 3'b111, 5'b0, 7'b1111111}
+
+`define INSTR_SLLIW      `IMM_SHIFT32_INSTR_CREATE(1'b0, 3'b001)
+`define INSTR_MASK_SLLIW `IMM_SHIFT32_INSTRS_MASK
+
+`define INSTR_SRLIW      `IMM_SHIFT32_INSTR_CREATE(1'b0, 3'b101)
+`define INSTR_MASK_SRLIW `IMM_SHIFT32_INSTRS_MASK
+
+`define INSTR_SRAIW      `IMM_SHIFT32_INSTR_CREATE(1'b1, 3'b101)
+`define INSTR_MASK_SRAIW `IMM_SHIFT32_INSTRS_MASK
 
 
 /* ------------------------------------------------------------------------- */
@@ -189,6 +246,39 @@
 
 `define INSTR_AND       `ALU_INSTR_CREATE(1'b0, 3'b111)
 `define INSTR_MASK_AND  `ALU_INSTRS_MASK
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * RV64I word-width register-register instructions (opcode 0111011),
+ * keyed on {bit30, funct3} exactly like ALU_INSTR_CREATE above, just at a
+ * different opcode. Only 5 of the 8 combinations base ALU_INSTR_CREATE
+ * supports are defined by the ISA here (no word-width OR/AND/XOR/SLT/
+ * SLTU -- bitwise and compare ops are identical whether you consider the
+ * upper 32 bits or not, so RV64I doesn't define separate "W" forms for
+ * them).
+ */
+
+`define ALU32_INSTR_CREATE(bit30, funct3) \
+                           {1'b0, bit30, 15'b0, funct3, 5'b0, 7'b0111011}
+`define ALU32_INSTRS_MASK     {7'b1111111, 10'b0, 3'b111, 5'b0, 7'b1111111}
+
+`define INSTR_ADDW       `ALU32_INSTR_CREATE(1'b0, 3'b000)
+`define INSTR_MASK_ADDW  `ALU32_INSTRS_MASK
+
+`define INSTR_SUBW       `ALU32_INSTR_CREATE(1'b1, 3'b000)
+`define INSTR_MASK_SUBW  `ALU32_INSTRS_MASK
+
+`define INSTR_SLLW       `ALU32_INSTR_CREATE(1'b0, 3'b001)
+`define INSTR_MASK_SLLW  `ALU32_INSTRS_MASK
+
+`define INSTR_SRLW       `ALU32_INSTR_CREATE(1'b0, 3'b101)
+`define INSTR_MASK_SRLW  `ALU32_INSTRS_MASK
+
+`define INSTR_SRAW       `ALU32_INSTR_CREATE(1'b1, 3'b101)
+`define INSTR_MASK_SRAW  `ALU32_INSTRS_MASK
 
 
 /* ------------------------------------------------------------------------- */

--- a/design/dmem.sv
+++ b/design/dmem.sv
@@ -1,0 +1,135 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+`include "defaults/defaults.sv"
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Module: Data memory
+ *
+ * Purpose-built for the single-cycle core, same reasoning as imem.sv:
+ * combinational read, no bus protocol. Unlike a Wishbone-attached memory
+ * (e.g. design/wb4_sram.sv), this isn't limited to 32-bit beats -- the
+ * data port is the full WORD_SIZE (64 bits) wide, so LD/SD complete as
+ * ordinary single-cycle accesses instead of needing two beats. Also
+ * unlike wb4_sram.sv, this has real byte enables, so SB/SH don't need a
+ * read-modify-write cycle to avoid corrupting the bytes around them --
+ * core.sv can just fire a single write with the right lanes enabled.
+ *
+ * i_size is deliberately 2 raw bits, not something ISA-aware like an
+ * opcode or funct3 field: it's literally funct3[1:0], which RISC-V
+ * encodes identically for every load AND store (00=byte, 01=half,
+ * 10=word, 11=doubleword), so core.sv can pass it straight through and
+ * this module never needs to `include any instruction-related header.
+ *
+ * Sign/zero-extension of load data is deliberately NOT this module's
+ * job -- LB and LBU read the physically identical byte; whether the
+ * result gets sign- or zero-extended is a register-width interpretation
+ * core.sv applies afterward, not a memory concern.
+ *
+ * Known, deliberate simplifications (consistent with everything else
+ * deferred out of this milestone -- see the top-level plan): no
+ * misaligned-access fault (an access whose byte_offset+size spills past
+ * the end of its 8-byte line silently drops the spilling bytes rather
+ * than faulting or spanning two lines) and no address-range fault (an
+ * out-of-range i_addr aliases via the bit-slice below rather than
+ * erroring, unlike wb4_sram.sv's addr_valid check). Testbenches for this
+ * milestone stick to naturally-aligned accesses within range.
+ *
+ * Parameters:
+ *  - num_words: number of WORD_SIZE-wide lines (default 4096 = 32 KB).
+ *  - l2_num_words: log2(num_words).
+ *
+ * Input ports:
+ *  i_clk: Clock (writes are synchronous; reads are not).
+ *  i_addr: Byte address.
+ *  i_size: Access width -- 2'b00=byte, 01=half, 10=word, 11=doubleword
+ *          (this is exactly funct3[1:0] for every RV64I load/store).
+ *  i_write_enable: High to write i_write_data on the next clock edge.
+ *  i_write_data: Data to write. The byte/half/word/doubleword being
+ *                stored is expected in this value's OWN low bits (i.e.
+ *                "the byte to store" in bits [7:0], regardless of where
+ *                it ends up landing in memory) -- this module shifts it
+ *                into the correct lane itself, core.sv doesn't need to.
+ *
+ * Output port:
+ *  o_read_data: The full WORD_SIZE-wide line containing i_addr,
+ *               combinationally, every cycle (regardless of i_size --
+ *               core.sv extracts/shifts out the piece it actually wants).
+ */
+module dmem #(
+    parameter num_words    = 4096,
+    parameter l2_num_words = 12
+) (
+    input  logic                       i_clk,
+    /*
+     * Only bits [l2_num_words+2:0] of i_addr are used (line_addr +
+     * byte_offset below) -- deliberate, per the address-range
+     * simplification documented above, not an oversight.
+     */
+    /* verilator lint_off UNUSEDSIGNAL */
+    input  logic [(`WORD_SIZE - 1):0]  i_addr,
+    /* verilator lint_on UNUSEDSIGNAL */
+    input  logic [1:0]                 i_size,
+    input  logic                       i_write_enable,
+    input  logic [(`WORD_SIZE - 1):0]  i_write_data,
+    output logic [(`WORD_SIZE - 1):0]  o_read_data
+);
+    logic [(`WORD_SIZE - 1):0] mem [0:(num_words - 1)];
+
+    /* Simulation-only zero-fill -- see imem.sv for why. */
+    integer init_i;
+    initial begin
+        for (init_i = 0; init_i < num_words; init_i = init_i + 1)
+            mem[init_i] = '0;
+    end
+
+    /*
+     * Each line is WORD_SIZE/8 = 8 bytes, so the low 3 address bits
+     * select a byte lane WITHIN a line, and everything above that
+     * selects the line itself.
+     */
+    wire [(l2_num_words - 1):0] line_addr   = i_addr[(l2_num_words + 2):3];
+    wire [2:0]                  byte_offset = i_addr[2:0];
+
+    assign o_read_data = mem[line_addr];
+
+    /*
+     * Byte-enable generation: start with a mask that has the right
+     * NUMBER of low bits set for the access size, then barrel-shift it
+     * left by byte_offset to slide those bits into the correct lane
+     * position. E.g. a halfword access at byte_offset=2 starts as
+     * 8'b00000011 and becomes 8'b00001100 -- lanes 2 and 3 enabled.
+     */
+    logic [7:0] size_mask, byte_enable;
+    always_comb begin: byte_enable_gen
+        case (i_size)
+            2'b00:   size_mask = 8'h01; // byte
+            2'b01:   size_mask = 8'h03; // halfword
+            2'b10:   size_mask = 8'h0F; // word
+            default: size_mask = 8'hFF; // 2'b11: doubleword
+        endcase
+        byte_enable = size_mask << byte_offset;
+    end: byte_enable_gen
+
+    /*
+     * Slide the write data into the same lane position byte_enable just
+     * computed, so "byte 0 of i_write_data" ends up at the enabled lane
+     * regardless of where that lane actually is within the line.
+     */
+    wire [(`WORD_SIZE - 1):0] shifted_write_data = i_write_data << (byte_offset * 8);
+
+    always_ff @(posedge i_clk) begin: write_port
+        if (i_write_enable) begin
+            for (int lane = 0; lane < 8; lane = lane + 1) begin
+                if (byte_enable[lane])
+                    mem[line_addr][(8 * lane) +: 8] <= shifted_write_data[(8 * lane) +: 8];
+            end
+        end
+    end: write_port
+endmodule

--- a/design/imem.sv
+++ b/design/imem.sv
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+`include "defaults/defaults.sv"
+`include "defaults/instruction_format.sv"
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Module: Instruction memory
+ *
+ * Purpose-built for the single-cycle core: combinational read only, no
+ * bus protocol at all. This is what makes single-cycle possible in the
+ * first place -- fetch, decode, execute, memory access and writeback all
+ * have to settle within one clock edge-to-edge cycle, so instruction
+ * memory can't have any registered read latency (unlike
+ * design/wb4_sram.sv, whose Wishbone ack is a clocked output and takes a
+ * minimum of 2 edges -- that's exactly why this core doesn't use it).
+ *
+ * Test programs are loaded by writing directly into `mem` via a
+ * hierarchical reference from the testbench (e.g.
+ * dut.imem_inst.mem[0] = 32'h...;) -- no loader task is needed since
+ * reads are combinational, so there's nothing to wait on after a write.
+ *
+ * Parameters:
+ *  - num_words: number of 32-bit instruction words (default 4096 = 16 KB).
+ *  - l2_num_words: log2(num_words).
+ *
+ * Input ports:
+ *  i_addr: Byte address to fetch from (= PC). Only bits
+ *          [l2_num_words+1:2] are used -- bits [1:0] are dropped (fetch
+ *          is always 4-byte aligned; there's no C extension yet to make
+ *          2-byte-aligned fetch meaningful) and everything above
+ *          l2_num_words+1 is dropped too (aliases within this memory's
+ *          range rather than faulting -- there's no address-range check,
+ *          matching dmem.sv's same simplification).
+ *
+ * Output port:
+ *  o_instruction: The 32-bit instruction at i_addr, combinationally.
+ */
+module imem #(
+    parameter num_words    = 4096,
+    parameter l2_num_words = 12
+) (
+    /*
+     * Only bits [l2_num_words+1:2] of i_addr are actually used (see
+     * o_instruction's assign below) -- deliberate, per the address-range
+     * simplification documented above, not an oversight. Silenced rather
+     * than left as a standing lint warning.
+     */
+    /* verilator lint_off UNUSEDSIGNAL */
+    input  logic [(`WORD_SIZE - 1):0]  i_addr,
+    /* verilator lint_on UNUSEDSIGNAL */
+    output logic [(`INSTR_SIZE - 1):0] o_instruction
+);
+    /*
+     * INSTR_SIZE here, not WORD_SIZE -- instructions stay 32 bits
+     * regardless of XLEN, the one place in this whole design where that
+     * distinction actually matters for a signal's width.
+     */
+    logic [(`INSTR_SIZE - 1):0] mem [0:(num_words - 1)];
+
+    /*
+     * Simulation-only zero-fill so an unloaded location reads as 0
+     * (which decodes as INVALID, see decoder.sv's default arm) instead
+     * of as 'X -- makes "the program ran off the end of what was loaded"
+     * behave predictably, and keeps waveform/$display output readable
+     * during bring-up. Real hardware has no such guarantee at power-on.
+     */
+    integer init_i;
+    initial begin
+        for (init_i = 0; init_i < num_words; init_i = init_i + 1)
+            mem[init_i] = '0;
+    end
+
+    assign o_instruction = mem[i_addr[(l2_num_words + 1):2]];
+endmodule

--- a/design/register_file.sv
+++ b/design/register_file.sv
@@ -19,18 +19,18 @@
  * Features:
  *  - Size = num_regs x WORD_SIZE
  *  - Dual port combinational reads and single port synchronous write.
- *  - Program counter read (comb) and write (sync).
- *  - Dedicated return address (r1) and stack pointer (r2) outputs.
+ *  - x0 always reads as 0, regardless of what (if anything) is ever
+ *    written to it -- writes to x0 are simply no-ops, as required by the
+ *    ISA. (No PC or dedicated RA/SP ports here -- those live in core.sv;
+ *    this module is a plain 32x64 register file.)
  *
  * Input ports:
  *  i_clk: Clock signal (positive edge is used for write).
  *  i_read_gpr_A_sel: Register select #1 for read.
  *  i_read_gpr_B_sel: Register select #2 for read.
- *  i_load_gpr: High to load into a register (r1 to r31 only).
- *  i_load_gpr_sel: Register select for load/write.
- *  i_load_gpr_data: Data to load into the selected register.
- *  i_load_pc: High to load into program counter (preferred).
- *  i_load_pc_data: Data to load in the program counter.
+ *  i_load_gpr: High to write i_load_gpr_data into the selected register.
+ *  i_load_gpr_sel: Register select for write.
+ *  i_load_gpr_data: Data to write into the selected register.
  *
  * Output ports:
  *  o_read_gpr_A_data: Data read from the selected register #1.
@@ -55,23 +55,40 @@ module register_file #(
     /* num_regs general purpose registers, each WORD_SIZE bit wide. */
     logic [(`WORD_SIZE - 1):0]  gp_registers [0:(num_regs - 1)];
 
+    /*
+     * Simulation-only zero-fill, same reasoning as imem.sv/dmem.sv: real
+     * hardware has no defined power-up register state, but zeroing here
+     * keeps waveform/$display output readable and makes "this register
+     * was never written" a clean, checkable 0 instead of 'X in
+     * testbenches.
+     */
+    integer init_i;
+    initial begin
+        for (init_i = 0; init_i < num_regs; init_i = init_i + 1)
+            gp_registers[init_i] = '0;
+    end
 
-    /* Read at both ports (NB: r0 is hardwired to 0). */
-    assign o_read_gpr_A_data = gp_registers[i_read_gpr_A_sel];
-    assign o_read_gpr_B_data = gp_registers[i_read_gpr_B_sel];
+    /*
+     * Read at both ports. x0 is forced to 0 here explicitly -- it's never
+     * actually written (see below), so without this the array's index-0
+     * slot would sit at its uninitialized 'X value for the entire
+     * simulation instead of reading as the architectural constant 0.
+     */
+    assign o_read_gpr_A_data = (i_read_gpr_A_sel == 0) ? '0 : gp_registers[i_read_gpr_A_sel];
+    assign o_read_gpr_B_data = (i_read_gpr_B_sel == 0) ? '0 : gp_registers[i_read_gpr_B_sel];
 
 
     /* Write. */
     always @(posedge i_clk) begin: write
         /*
-         * Load GPR.
-         * NB: We don't write at r0. Thus, select must be non-zero.
+         * Write only when the caller asks for one (i_load_gpr) AND targets
+         * a real register (i_load_gpr_sel != 0 -- x0 excluded, since
+         * writes to it are architecturally no-ops; handled here by simply
+         * never writing gp_registers[0], rather than writing it and
+         * masking the value back out on read).
          */
-        if (i_load_gpr_sel) begin: load_gpr
-            if (i_load_gpr)
-                gp_registers[0] <= 0;
-            else
-                gp_registers[i_load_gpr_sel] <= i_load_gpr_data;
+        if (i_load_gpr && (i_load_gpr_sel != 0)) begin: load_gpr
+            gp_registers[i_load_gpr_sel] <= i_load_gpr_data;
         end: load_gpr
     end: write
 endmodule: register_file

--- a/design/register_file_tb.sv
+++ b/design/register_file_tb.sv
@@ -1,0 +1,121 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+`include "defaults/defaults.sv"
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Testbench: register_file
+ *
+ * Needs a clock (writes are synchronous) but no reset port -- there isn't
+ * one on this module by design, x0 is forced to 0 by the read mux instead
+ * of by a reset sequence (see the first test below).
+ */
+module register_file_tb;
+
+    logic clk = 0;
+    always #5 clk = ~clk;
+
+    logic [(`L2_REG_FILE_SIZE - 1):0] read_A_sel, read_B_sel;
+    logic [(`WORD_SIZE - 1):0]        read_A_data, read_B_data;
+    logic                              load_gpr;
+    logic [(`L2_REG_FILE_SIZE - 1):0] load_gpr_sel;
+    logic [(`WORD_SIZE - 1):0]        load_gpr_data;
+
+    register_file dut (
+        .i_clk(clk),
+        .i_read_gpr_A_sel(read_A_sel), .o_read_gpr_A_data(read_A_data),
+        .i_read_gpr_B_sel(read_B_sel), .o_read_gpr_B_data(read_B_data),
+        .i_load_gpr(load_gpr), .i_load_gpr_sel(load_gpr_sel), .i_load_gpr_data(load_gpr_data)
+    );
+
+    int pass_count = 0;
+    int fail_count = 0;
+
+    task automatic check(string name, logic [(`WORD_SIZE-1):0] actual, logic [(`WORD_SIZE-1):0] expected);
+        if (actual === expected) begin
+            pass_count++;
+            $display("PASS: %s", name);
+        end else begin
+            fail_count++;
+            $display("FAIL: %s -- expected %h, got %h", name, expected, actual);
+        end
+    endtask
+
+    initial begin
+        load_gpr = 0; load_gpr_sel = 0; load_gpr_data = 0;
+        read_A_sel = 0; read_B_sel = 0;
+
+        /*
+         * x0 reads 0 with no clock edge having occurred at all yet -- this
+         * specifically proves the read mux forces it (combinational),
+         * distinct from "it happens to read 0 because we reset/wrote it".
+         */
+        #1;
+        check("x0 reads 0 before any clock edge", read_A_data, 64'd0);
+
+        /*
+         * Basic write/read-back: write x5, then read it on port A.
+         */
+        @(negedge clk);
+        load_gpr = 1; load_gpr_sel = 5; load_gpr_data = 64'hDEADBEEF_00000005;
+        @(posedge clk); #1;
+        load_gpr = 0;
+        read_A_sel = 5;
+        #1;
+        check("write x5 then read back on port A", read_A_data, 64'hDEADBEEF_00000005);
+
+        /*
+         * Write-enable LOW must NOT write -- direct regression for the
+         * inverted-polarity bug, where write-enable low used to be exactly
+         * the condition that DID write. Attempt to overwrite x6 with the
+         * enable held low; x6 must stay at its (uninitialized-but-never-
+         * written) state, which we prove indirectly by writing a KNOWN
+         * value with the enable low, then writing a DIFFERENT known value
+         * with the enable high, and confirming only the second one stuck.
+         */
+        @(negedge clk);
+        load_gpr = 0; load_gpr_sel = 6; load_gpr_data = 64'hBAD0BAD0_BAD0BAD0; // enable LOW: must not write
+        @(posedge clk); #1;
+        @(negedge clk);
+        load_gpr = 1; load_gpr_sel = 6; load_gpr_data = 64'h6000600060006000; // enable HIGH: must write
+        @(posedge clk); #1;
+        load_gpr = 0;
+        read_A_sel = 6;
+        #1;
+        check("write-enable low did not write (polarity regression)", read_A_data, 64'h6000600060006000);
+
+        /*
+         * Attempted write to x0 must be a no-op -- x0 always reads 0
+         * afterward regardless.
+         */
+        @(negedge clk);
+        load_gpr = 1; load_gpr_sel = 0; load_gpr_data = 64'hFFFFFFFF_FFFFFFFF;
+        @(posedge clk); #1;
+        load_gpr = 0;
+        read_A_sel = 0;
+        #1;
+        check("write to x0 is a no-op", read_A_data, 64'd0);
+
+        /*
+         * Dual-port simultaneous read: x5 and x6 (both written above) read
+         * out correctly and independently on the same cycle, from the two
+         * separate read ports.
+         */
+        read_A_sel = 5; read_B_sel = 6;
+        #1;
+        check("dual-port read, port A (x5)", read_A_data, 64'hDEADBEEF_00000005);
+        check("dual-port read, port B (x6)", read_B_data, 64'h6000600060006000);
+
+        $display("");
+        $display("register_file_tb: %0d passed, %0d failed", pass_count, fail_count);
+        if (fail_count > 0) $display("register_file_tb: FAILURES PRESENT");
+        $finish;
+    end
+
+endmodule

--- a/testbench/core_alu_ops_tb.sv
+++ b/testbench/core_alu_ops_tb.sv
@@ -1,0 +1,94 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+`include "defaults/defaults.sv"
+`include "riscv_encode.sv"
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Testbench: core, register-immediate / register-register ALU ops
+ *
+ * First integration test -- exercises the plain fetch -> decode -> ALU ->
+ * writeback path only, no memory or branch/jump complexity yet (those
+ * are added one at a time by the testbenches after this one).
+ *
+ * Instructions are hand-encoded via riscv_encode.sv and poked directly
+ * into imem0 -- no riscv64-unknown-elf toolchain dependency for this
+ * stage.
+ */
+module core_alu_ops_tb;
+
+    logic clk = 0;
+    always #5 clk = ~clk;
+
+    logic rst = 1;
+
+    core dut (.clk(clk), .rst(rst));
+
+    int pass_count = 0;
+    int fail_count = 0;
+    task automatic check_reg(string name, int idx, logic [(`WORD_SIZE-1):0] expected);
+        if (dut.regfile0.gp_registers[idx] === expected) begin
+            pass_count++;
+            $display("PASS: %s", name);
+        end else begin
+            fail_count++;
+            $display("FAIL: %s -- expected %h, got %h", name, expected, dut.regfile0.gp_registers[idx]);
+        end
+    endtask
+
+    initial begin
+        /*
+         * addi x1, x0, 5        x1 = 5
+         * addi x2, x0, -3       x2 = -3  (negative I-immediate sign-extension)
+         * add  x3, x1, x2       x3 = 5 + (-3) = 2
+         * sub  x4, x1, x2       x4 = 5 - (-3) = 8
+         * slti x5, x2, 0        x5 = (x2 < 0) ? 1 : 0 = 1  (signed compare, negative operand)
+         * slli x6, x1, 2        x6 = 5 << 2 = 20  (shamt-routing regression: the old bug read
+         *                                          the whole imm field as shamt, not just bits[24:20])
+         * srai x7, x2, 1        x7 = (-3) >>> 1 = -2  (needs BOTH the shamt fix and the ALU's
+         *                                              SRA fix to land on the right answer)
+         * ebreak
+         */
+        dut.imem0.mem[0] = encode_i(32'sd5, 5'd0, 3'b000, 5'd1, `OPC_OP_IMM);
+        dut.imem0.mem[1] = encode_i(-32'sd3, 5'd0, 3'b000, 5'd2, `OPC_OP_IMM);
+        dut.imem0.mem[2] = encode_r(7'b0000000, 5'd2, 5'd1, 3'b000, 5'd3, `OPC_OP);
+        dut.imem0.mem[3] = encode_r(7'b0100000, 5'd2, 5'd1, 3'b000, 5'd4, `OPC_OP);
+        dut.imem0.mem[4] = encode_i(32'sd0, 5'd2, 3'b010, 5'd5, `OPC_OP_IMM);
+        dut.imem0.mem[5] = encode_shift64(6'b000000, 6'd2, 5'd1, 3'b001, 5'd6, `OPC_OP_IMM);
+        dut.imem0.mem[6] = encode_shift64(6'b010000, 6'd1, 5'd2, 3'b101, 5'd7, `OPC_OP_IMM);
+        dut.imem0.mem[7] = {11'b0, 1'b1, 13'b0, `OPC_SYSTEM}; // ebreak
+
+        @(posedge clk); #1;
+        rst = 0;
+
+        fork
+            wait (dut.halted === 1'b1);
+            begin
+                repeat (50) @(posedge clk);
+                $display("TIMEOUT: dut.halted never went high");
+                $finish;
+            end
+        join_any
+        #1;
+
+        check_reg("x1 (addi positive)",    1, 64'd5);
+        check_reg("x2 (addi negative)",    2, -64'sd3);
+        check_reg("x3 (add)",              3, 64'd2);
+        check_reg("x4 (sub)",              4, 64'd8);
+        check_reg("x5 (slti, neg < 0)",    5, 64'd1);
+        check_reg("x6 (slli shamt route)", 6, 64'd20);
+        check_reg("x7 (srai neg, fixed)",  7, -64'sd2);
+
+        $display("");
+        $display("core_alu_ops_tb: %0d passed, %0d failed", pass_count, fail_count);
+        if (fail_count > 0) $display("core_alu_ops_tb: FAILURES PRESENT");
+        $finish;
+    end
+
+endmodule

--- a/testbench/core_branch_jump_tb.sv
+++ b/testbench/core_branch_jump_tb.sv
@@ -1,0 +1,126 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+`include "defaults/defaults.sv"
+`include "riscv_encode.sv"
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Testbench: core, branches and jumps
+ *
+ * Adds the next-PC mux on top of core_alu_ops_tb's plain path.
+ *
+ * Every "branch taken" case below uses a skip-sentinel-then-escape
+ * pattern, not just a skip: the sentinel write happens if the branch is
+ * WRONGLY not taken, followed by an unconditional jump PAST the "landed
+ * correctly" instruction. Without the escape jump, a branch that never
+ * takes at all would still fall through both instructions sequentially
+ * and end up looking identical to a correctly-taken branch (the sentinel
+ * gets overwritten by the "landed" value either way) -- the escape jump
+ * is what makes the two cases actually distinguishable.
+ */
+module core_branch_jump_tb;
+
+    logic clk = 0;
+    always #5 clk = ~clk;
+
+    logic rst = 1;
+
+    core dut (.clk(clk), .rst(rst));
+
+    int pass_count = 0;
+    int fail_count = 0;
+    task automatic check_reg(string name, int idx, logic [(`WORD_SIZE-1):0] expected);
+        if (dut.regfile0.gp_registers[idx] === expected) begin
+            pass_count++;
+            $display("PASS: %s", name);
+        end else begin
+            fail_count++;
+            $display("FAIL: %s -- expected %h, got %h", name, expected, dut.regfile0.gp_registers[idx]);
+        end
+    endtask
+
+    initial begin
+        /*
+         * addr  idx  instruction                    notes
+         *  0     0   addi x1,x0,1
+         *  4     1   addi x2,x0,1
+         *  8     2   beq  x1,x2,12      -> 20        beq IS taken (1==1)
+         * 12     3   addi x3,x0,111                  sentinel: reached only if beq wrongly not-taken
+         * 16     4   jal  x0,8          -> 24         escape, only reached from idx3
+         * 20     5   addi x3,x0,222                  correct landing; falls through to idx6
+         * 24     6   addi x4,x0,-1
+         * 28     7   addi x5,x0,1
+         * 32     8   blt  x4,x5,12      -> 44         blt IS taken (signed -1 < 1)
+         * 36     9   addi x6,x0,111                  sentinel
+         * 40    10   jal  x0,8          -> 48         escape
+         * 44    11   addi x6,x0,222                  correct landing; falls through to idx12
+         * 48    12   bltu x4,x5,12      -> 60         bltu is NOT taken (unsigned huge < 1 is false)
+         * 52    13   addi x7,x0,222                  correct fallthrough (bltu not taken)
+         * 56    14   jal  x0,8          -> 64         escape, only reached from idx13's correct path
+         * 60    15   addi x7,x0,111                  wrong-landing zone; reached only if bltu wrongly taken
+         * 64    16   jal  x8,8          -> 72         link(x8) = 64+4 = 68
+         * 68    17   addi x9,x0,111                  skipped by the jal above
+         * 72    18   addi x11,x0,78                  jal lands here
+         * 76    19   jalr x10,x11,7     raw=78+7=85(odd) -> cleared 84; link(x10)=76+4=80
+         * 80    20   addi x12,x0,111                 skipped
+         * 84    21   addi x12,x0,222                 jalr lands here
+         * 88    22   ebreak
+         */
+        dut.imem0.mem[0]  = encode_i(32'sd1, 5'd0, 3'b000, 5'd1, `OPC_OP_IMM);
+        dut.imem0.mem[1]  = encode_i(32'sd1, 5'd0, 3'b000, 5'd2, `OPC_OP_IMM);
+        dut.imem0.mem[2]  = encode_b(32'sd12, 5'd2, 5'd1, 3'b000, `OPC_BRANCH); // beq
+        dut.imem0.mem[3]  = encode_i(32'sd111, 5'd0, 3'b000, 5'd3, `OPC_OP_IMM);
+        dut.imem0.mem[4]  = encode_j(32'sd8, 5'd0, `OPC_JAL);
+        dut.imem0.mem[5]  = encode_i(32'sd222, 5'd0, 3'b000, 5'd3, `OPC_OP_IMM);
+        dut.imem0.mem[6]  = encode_i(-32'sd1, 5'd0, 3'b000, 5'd4, `OPC_OP_IMM);
+        dut.imem0.mem[7]  = encode_i(32'sd1, 5'd0, 3'b000, 5'd5, `OPC_OP_IMM);
+        dut.imem0.mem[8]  = encode_b(32'sd12, 5'd5, 5'd4, 3'b100, `OPC_BRANCH); // blt
+        dut.imem0.mem[9]  = encode_i(32'sd111, 5'd0, 3'b000, 5'd6, `OPC_OP_IMM);
+        dut.imem0.mem[10] = encode_j(32'sd8, 5'd0, `OPC_JAL);
+        dut.imem0.mem[11] = encode_i(32'sd222, 5'd0, 3'b000, 5'd6, `OPC_OP_IMM);
+        dut.imem0.mem[12] = encode_b(32'sd12, 5'd5, 5'd4, 3'b110, `OPC_BRANCH); // bltu
+        dut.imem0.mem[13] = encode_i(32'sd222, 5'd0, 3'b000, 5'd7, `OPC_OP_IMM);
+        dut.imem0.mem[14] = encode_j(32'sd8, 5'd0, `OPC_JAL);
+        dut.imem0.mem[15] = encode_i(32'sd111, 5'd0, 3'b000, 5'd7, `OPC_OP_IMM);
+        dut.imem0.mem[16] = encode_j(32'sd8, 5'd8, `OPC_JAL);
+        dut.imem0.mem[17] = encode_i(32'sd111, 5'd0, 3'b000, 5'd9, `OPC_OP_IMM);
+        dut.imem0.mem[18] = encode_i(32'sd78, 5'd0, 3'b000, 5'd11, `OPC_OP_IMM);
+        dut.imem0.mem[19] = encode_i(32'sd7, 5'd11, 3'b000, 5'd10, `OPC_JALR);
+        dut.imem0.mem[20] = encode_i(32'sd111, 5'd0, 3'b000, 5'd12, `OPC_OP_IMM);
+        dut.imem0.mem[21] = encode_i(32'sd222, 5'd0, 3'b000, 5'd12, `OPC_OP_IMM);
+        dut.imem0.mem[22] = {11'b0, 1'b1, 13'b0, `OPC_SYSTEM}; // ebreak
+
+        @(posedge clk); #1;
+        rst = 0;
+
+        fork
+            wait (dut.halted === 1'b1);
+            begin
+                repeat (60) @(posedge clk);
+                $display("TIMEOUT: dut.halted never went high");
+                $finish;
+            end
+        join_any
+        #1;
+
+        check_reg("x3 (beq taken)",              3, 64'd222);
+        check_reg("x6 (blt taken, signed)",       6, 64'd222);
+        check_reg("x7 (bltu not taken, unsigned)",7, 64'd222);
+        check_reg("x8 (jal link value)",          8, 64'd68);
+        check_reg("x9 (skipped by jal)",          9, 64'd0);
+        check_reg("x10 (jalr link value)",       10, 64'd80);
+        check_reg("x12 (jalr LSB-clear fix)",    12, 64'd222);
+
+        $display("");
+        $display("core_branch_jump_tb: %0d passed, %0d failed", pass_count, fail_count);
+        if (fail_count > 0) $display("core_branch_jump_tb: FAILURES PRESENT");
+        $finish;
+    end
+
+endmodule

--- a/testbench/core_load_store_tb.sv
+++ b/testbench/core_load_store_tb.sv
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+`include "defaults/defaults.sv"
+`include "riscv_encode.sv"
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Testbench: core, loads and stores
+ *
+ * Adds the memory subsystem (dmem, byte-enable writes) on top of
+ * core_alu_ops_tb's plain path.
+ *
+ * The negative-offset SW case is the important one: SW's address comes
+ * from imm_s (S-type), which had the 12-vs-13-bit zero-pad bug -- LW's
+ * address comes from imm_i (I-type), which never had that bug. So
+ * storing at a negative S-type offset and reading back from the SAME
+ * negative I-type offset is a real regression check: if SW's offset
+ * decode is still broken, the two addresses land in different places and
+ * the load-back reads back 0 (uninitialized), not the stored value.
+ */
+module core_load_store_tb;
+
+    logic clk = 0;
+    always #5 clk = ~clk;
+
+    logic rst = 1;
+
+    core dut (.clk(clk), .rst(rst));
+
+    int pass_count = 0;
+    int fail_count = 0;
+    task automatic check_reg(string name, int idx, logic [(`WORD_SIZE-1):0] expected);
+        if (dut.regfile0.gp_registers[idx] === expected) begin
+            pass_count++;
+            $display("PASS: %s", name);
+        end else begin
+            fail_count++;
+            $display("FAIL: %s -- expected %h, got %h", name, expected, dut.regfile0.gp_registers[idx]);
+        end
+    endtask
+
+    initial begin
+        /*
+         * addi x1, x0, 0x100    base address for the byte test
+         * addi x2, x0, -1       x2 = 0xFFFF...FFFF (low byte = 0xFF)
+         * sb   x2, 0(x1)        mem[0x100] = 0xFF
+         * lb   x3, 0(x1)        x3 = sext8(0xFF)  = 0xFFFF...FFFF  (signed read)
+         * lbu  x4, 0(x1)        x4 = zext8(0xFF)  = 0x0000...00FF  (unsigned read of the SAME byte)
+         * sd   x2, 8(x1)        mem[0x108..0x10F] = 0xFFFF...FFFF
+         * ld   x5, 8(x1)        x5 = 0xFFFF...FFFF  (full 64-bit round trip)
+         *
+         * addi x7, x0, 0x200    base address for the negative-offset test
+         * addi x8, x0, 0x555    test value
+         * sw   x8, -4(x7)       mem[0x1FC] = 0x555  (S-type negative offset -- the regression)
+         * lw   x9, -4(x7)       x9 = mem[0x1FC]  (I-type negative offset -- independently correct,
+         *                        used here as the check)
+         * ebreak
+         */
+        dut.imem0.mem[0]  = encode_i(32'sh100, 5'd0, 3'b000, 5'd1, `OPC_OP_IMM);
+        dut.imem0.mem[1]  = encode_i(-32'sd1, 5'd0, 3'b000, 5'd2, `OPC_OP_IMM);
+        dut.imem0.mem[2]  = encode_s(32'sd0, 5'd2, 5'd1, 3'b000, `OPC_STORE);
+        dut.imem0.mem[3]  = encode_i(32'sd0, 5'd1, 3'b000, 5'd3, `OPC_LOAD);
+        dut.imem0.mem[4]  = encode_i(32'sd0, 5'd1, 3'b100, 5'd4, `OPC_LOAD);
+        dut.imem0.mem[5]  = encode_s(32'sd8, 5'd2, 5'd1, 3'b011, `OPC_STORE);
+        dut.imem0.mem[6]  = encode_i(32'sd8, 5'd1, 3'b011, 5'd5, `OPC_LOAD);
+        dut.imem0.mem[7]  = encode_i(32'sh200, 5'd0, 3'b000, 5'd7, `OPC_OP_IMM);
+        dut.imem0.mem[8]  = encode_i(32'sh555, 5'd0, 3'b000, 5'd8, `OPC_OP_IMM);
+        dut.imem0.mem[9]  = encode_s(-32'sd4, 5'd8, 5'd7, 3'b010, `OPC_STORE);
+        dut.imem0.mem[10] = encode_i(-32'sd4, 5'd7, 3'b010, 5'd9, `OPC_LOAD);
+        dut.imem0.mem[11] = {11'b0, 1'b1, 13'b0, `OPC_SYSTEM}; // ebreak
+
+        @(posedge clk); #1;
+        rst = 0;
+
+        fork
+            wait (dut.halted === 1'b1);
+            begin
+                repeat (50) @(posedge clk);
+                $display("TIMEOUT: dut.halted never went high");
+                $finish;
+            end
+        join_any
+        #1;
+
+        check_reg("x3 (lb, signed read of 0xFF)",   3, 64'hFFFFFFFFFFFFFFFF);
+        check_reg("x4 (lbu, unsigned read of 0xFF)", 4, 64'h00000000000000FF);
+        check_reg("x5 (sd/ld round trip)",           5, 64'hFFFFFFFFFFFFFFFF);
+        check_reg("x9 (sw negative offset, verified via lw)", 9, 64'h0000000000000555);
+
+        $display("");
+        $display("core_load_store_tb: %0d passed, %0d failed", pass_count, fail_count);
+        if (fail_count > 0) $display("core_load_store_tb: FAILURES PRESENT");
+        $finish;
+    end
+
+endmodule

--- a/testbench/core_rv64_word_ops_tb.sv
+++ b/testbench/core_rv64_word_ops_tb.sv
@@ -1,0 +1,109 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+`include "defaults/defaults.sv"
+`include "riscv_encode.sv"
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Testbench: core, RV64I word-arithmetic family (the *W and *IW ops)
+ *
+ * Newest, most RV64I-specific logic -- run last, since everything it
+ * depends on (ALU, decoder, regfile, the whole non-word datapath) is
+ * already proven by the earlier testbenches.
+ *
+ * The decisive technique throughout: build one value in x1 whose full
+ * 64-bit form is POSITIVE but whose low 32 bits, read as a 32-bit signed
+ * value, are NEGATIVE (-1) -- then run both a *W op and its plain 64-bit
+ * equivalent on the SAME source register. If *W is truncating correctly,
+ * it sees the negative 32-bit view and its result goes negative; if it
+ * were (incorrectly) just an alias for the 64-bit op, it would see the
+ * positive 64-bit view instead. The two results landing in different
+ * registers, computed from identical inputs, is the proof.
+ */
+module core_rv64_word_ops_tb;
+
+    logic clk = 0;
+    always #5 clk = ~clk;
+
+    logic rst = 1;
+
+    core dut (.clk(clk), .rst(rst));
+
+    int pass_count = 0;
+    int fail_count = 0;
+    task automatic check_reg(string name, int idx, logic [(`WORD_SIZE-1):0] expected);
+        if (dut.regfile0.gp_registers[idx] === expected) begin
+            pass_count++;
+            $display("PASS: %s", name);
+        end else begin
+            fail_count++;
+            $display("FAIL: %s -- expected %h, got %h", name, expected, dut.regfile0.gp_registers[idx]);
+        end
+    endtask
+
+    initial begin
+        /*
+         * addi x1,x0,-1     x1 = 0xFFFFFFFFFFFFFFFF
+         * slli x1,x1,32     x1 = 0xFFFFFFFF00000000
+         * srli x1,x1,32     x1 = 0x00000000FFFFFFFF   (setup: positive 64-bit,
+         *                                               low 32 bits = -1 as int32)
+         *
+         * addw x2,x1,x0     x2 = sext32(lo32(x1) + 0) = sext32(0xFFFFFFFF) = 0xFFFF...FFFF  (negative)
+         * add  x3,x1,x0     x3 = x1 + 0             = 0x00000000FFFFFFFF                    (stays positive --
+         *                                              proves ADD does NOT truncate the way ADDW does)
+         *
+         * addi x5,x0,4      x5 = 4  (shift amount register)
+         * sraw x6,x1,x5     x6 = sext32(arith_shift(lo32(x1),4)) = sext32(0xFFFFFFFF) = 0xFFFF...FFFF (stays negative)
+         * srlw x7,x1,x5     x7 = sext32(logic_shift(lo32(x1),4)) = sext32(0x0FFFFFFF) = 0x000...0FFFFFFF
+         *                        (positive -- logical shift zero-filled bit 31 of the 32-bit
+         *                         result, and THAT bit is what the final sign-extension uses)
+         *
+         * addiw x9,x1,1     x9 = sext32(lo32(x1) + 1) = sext32(0xFFFFFFFF + 1) = sext32(0) = 0
+         *                        (a buggy "just ADD in 64-bit" implementation would instead give
+         *                         0x0000000100000000 -- completely different, easy to catch)
+         * ebreak
+         */
+        dut.imem0.mem[0] = encode_i(-32'sd1, 5'd0, 3'b000, 5'd1, `OPC_OP_IMM);
+        dut.imem0.mem[1] = encode_shift64(6'b000000, 6'd32, 5'd1, 3'b001, 5'd1, `OPC_OP_IMM); // slli
+        dut.imem0.mem[2] = encode_shift64(6'b000000, 6'd32, 5'd1, 3'b101, 5'd1, `OPC_OP_IMM); // srli
+        dut.imem0.mem[3] = encode_r(7'b0000000, 5'd0, 5'd1, 3'b000, 5'd2, `OPC_OP_32);        // addw
+        dut.imem0.mem[4] = encode_r(7'b0000000, 5'd0, 5'd1, 3'b000, 5'd3, `OPC_OP);           // add
+        dut.imem0.mem[5] = encode_i(32'sd4, 5'd0, 3'b000, 5'd5, `OPC_OP_IMM);                 // addi x5,x0,4
+        dut.imem0.mem[6] = encode_r(7'b0100000, 5'd5, 5'd1, 3'b101, 5'd6, `OPC_OP_32);        // sraw
+        dut.imem0.mem[7] = encode_r(7'b0000000, 5'd5, 5'd1, 3'b101, 5'd7, `OPC_OP_32);        // srlw
+        dut.imem0.mem[8] = encode_i(32'sd1, 5'd1, 3'b000, 5'd9, `OPC_OP_IMM_32);              // addiw
+        dut.imem0.mem[9] = {11'b0, 1'b1, 13'b0, `OPC_SYSTEM};                                  // ebreak
+
+        @(posedge clk); #1;
+        rst = 0;
+
+        fork
+            wait (dut.halted === 1'b1);
+            begin
+                repeat (50) @(posedge clk);
+                $display("TIMEOUT: dut.halted never went high");
+                $finish;
+            end
+        join_any
+        #1;
+
+        check_reg("x1 (setup: positive 64-bit, negative low32)", 1, 64'h00000000FFFFFFFF);
+        check_reg("x2 (addw truncates+resigns -> negative)",      2, 64'hFFFFFFFFFFFFFFFF);
+        check_reg("x3 (add does NOT truncate -> stays positive)", 3, 64'h00000000FFFFFFFF);
+        check_reg("x6 (sraw stays negative)",                     6, 64'hFFFFFFFFFFFFFFFF);
+        check_reg("x7 (srlw -> positive after zero-fill)",        7, 64'h000000000FFFFFFF);
+        check_reg("x9 (addiw truncates+resigns -> 0, not 2^32)",  9, 64'h0000000000000000);
+
+        $display("");
+        $display("core_rv64_word_ops_tb: %0d passed, %0d failed", pass_count, fail_count);
+        if (fail_count > 0) $display("core_rv64_word_ops_tb: FAILURES PRESENT");
+        $finish;
+    end
+
+endmodule

--- a/testbench/core_upper_imm_tb.sv
+++ b/testbench/core_upper_imm_tb.sv
@@ -1,0 +1,79 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+`include "defaults/defaults.sv"
+`include "riscv_encode.sv"
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Testbench: core, LUI / AUIPC
+ *
+ * Adds only the U-type operand-mux subtlety on top of core_alu_ops_tb's
+ * plain path -- see the AUIPC comment in core.sv for the full story on
+ * why AUIPC needs both ALU operands swapped, not just A.
+ */
+module core_upper_imm_tb;
+
+    logic clk = 0;
+    always #5 clk = ~clk;
+
+    logic rst = 1;
+
+    core dut (.clk(clk), .rst(rst));
+
+    int pass_count = 0;
+    int fail_count = 0;
+    task automatic check_reg(string name, int idx, logic [(`WORD_SIZE-1):0] expected);
+        if (dut.regfile0.gp_registers[idx] === expected) begin
+            pass_count++;
+            $display("PASS: %s", name);
+        end else begin
+            fail_count++;
+            $display("FAIL: %s -- expected %h, got %h", name, expected, dut.regfile0.gp_registers[idx]);
+        end
+    endtask
+
+    initial begin
+        /*
+         * lui x1, 0xFFFFF      x1 = 0xFFFFFFFFFFFFF000  (bit 19 set -> must sign-extend
+         *                       negative; the old bug never shifted at all, so this would
+         *                       have produced 0x00000000000FFFFF instead)
+         * lui x2, 0x00001      x2 = 0x0000000000001000  (bit 19 clear -> stays positive,
+         *                       contrasting case)
+         * auipc x3, 0x00001    at PC=0x8: x3 = 0x8 + 0x1000 = 0x1008
+         * ebreak
+         */
+        dut.imem0.mem[0] = encode_u(20'hFFFFF, 5'd1, `OPC_LUI);
+        dut.imem0.mem[1] = encode_u(20'h00001, 5'd2, `OPC_LUI);
+        dut.imem0.mem[2] = encode_u(20'h00001, 5'd3, `OPC_AUIPC);
+        dut.imem0.mem[3] = {11'b0, 1'b1, 13'b0, `OPC_SYSTEM}; // ebreak
+
+        @(posedge clk); #1;
+        rst = 0;
+
+        fork
+            wait (dut.halted === 1'b1);
+            begin
+                repeat (50) @(posedge clk);
+                $display("TIMEOUT: dut.halted never went high");
+                $finish;
+            end
+        join_any
+        #1;
+
+        check_reg("x1 (lui, bit19 set -> negative)", 1, 64'hFFFFFFFFFFFFF000);
+        check_reg("x2 (lui, bit19 clear -> positive)", 2, 64'h0000000000001000);
+        check_reg("x3 (auipc, pc + imm)", 3, 64'h0000000000001008);
+
+        $display("");
+        $display("core_upper_imm_tb: %0d passed, %0d failed", pass_count, fail_count);
+        if (fail_count > 0) $display("core_upper_imm_tb: FAILURES PRESENT");
+        $finish;
+    end
+
+endmodule

--- a/testbench/riscv_encode.sv
+++ b/testbench/riscv_encode.sv
@@ -1,0 +1,130 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Small helper functions for hand-assembling RV64I instruction encodings
+ * directly inside a testbench, without depending on the
+ * riscv64-unknown-elf toolchain -- decouples RTL verification from that
+ * toolchain's availability, and keeps the small, per-feature testbenches
+ * in this milestone fast to write and iterate on.
+ *
+ * Each function takes named fields (never raw hex) and returns the
+ * assembled 32-bit instruction word. Bit layouts here were checked
+ * directly against decoder.sv's field-extraction code (imm_s/imm_b/
+ * imm_u/imm_j, etc.), not just against the ISA spec, so an encoder/
+ * decoder mismatch would show up as a wrong-looking test result rather
+ * than silently canceling out.
+ *
+ * Immediates are accepted as plain `int` (32-bit signed) except encode_u,
+ * where the field is inherently unshifted/unsigned at the encoding level
+ * (see its own comment) -- callers write ordinary signed literals (e.g.
+ * -5), and each function extracts exactly the bits it needs.
+ */
+
+function automatic logic [31:0] encode_r(
+    input logic [6:0] funct7, input logic [4:0] rs2, input logic [4:0] rs1,
+    input logic [2:0] funct3, input logic [4:0] rd, input logic [6:0] opcode
+);
+    return {funct7, rs2, rs1, funct3, rd, opcode};
+endfunction
+
+function automatic logic [31:0] encode_i(
+    input int imm, input logic [4:0] rs1, input logic [2:0] funct3,
+    input logic [4:0] rd, input logic [6:0] opcode
+);
+    return {imm[11:0], rs1, funct3, rd, opcode};
+endfunction
+
+/*
+ * Shift-immediate, RV64I base shifts (SLLI/SRLI/SRAI): 6-bit shamt,
+ * 6-bit funct6 -- bit 25, which used to be funct7's LSB under RV32I, is
+ * now shamt's top bit (see instructions_and_masks.sv's IMM_SHIFT fix).
+ * Distinct from encode_shift32w below -- mixing these two up produces a
+ * validly-formed but WRONG instruction, not a compile error, so keep
+ * them separate rather than one function with an ambiguous "does bit 25
+ * mean funct7 or shamt" parameter.
+ */
+function automatic logic [31:0] encode_shift64(
+    input logic [5:0] funct6, input logic [5:0] shamt, input logic [4:0] rs1,
+    input logic [2:0] funct3, input logic [4:0] rd, input logic [6:0] opcode
+);
+    return {funct6, shamt, rs1, funct3, rd, opcode};
+endfunction
+
+/*
+ * Shift-immediate, RV64I word shifts (SLLIW/SRLIW/SRAIW): these stay at
+ * a 5-bit shamt (word-shifts are always 32-bit) with a full 7-bit
+ * funct7, same shape as the ORIGINAL RV32I base-shift encoding, just at
+ * a different opcode.
+ */
+function automatic logic [31:0] encode_shift32w(
+    input logic [6:0] funct7, input logic [4:0] shamt, input logic [4:0] rs1,
+    input logic [2:0] funct3, input logic [4:0] rd, input logic [6:0] opcode
+);
+    return {funct7, shamt, rs1, funct3, rd, opcode};
+endfunction
+
+function automatic logic [31:0] encode_s(
+    input int imm, input logic [4:0] rs2, input logic [4:0] rs1,
+    input logic [2:0] funct3, input logic [6:0] opcode
+);
+    return {imm[11:5], rs2, rs1, funct3, imm[4:0], opcode};
+endfunction
+
+/*
+ * imm is the actual branch offset in bytes -- must be even (bit 0 is
+ * architecturally always 0 and isn't stored), matching how a real
+ * assembler takes a branch target label, not a pre-shifted encoding.
+ */
+function automatic logic [31:0] encode_b(
+    input int imm, input logic [4:0] rs2, input logic [4:0] rs1,
+    input logic [2:0] funct3, input logic [6:0] opcode
+);
+    return {imm[12], imm[10:5], rs2, rs1, funct3, imm[4:1], imm[11], opcode};
+endfunction
+
+/*
+ * imm is the raw 20-bit field that lands directly in bits [31:12] --
+ * i.e. NOT pre-shifted-then-truncated, the same convention real
+ * assembly's `lui`/`auipc` immediate uses. Turning this into an actual
+ * address-sized value (shifting into place, sign-extending) is
+ * decoder.sv's job (imm_u_sext), not this function's.
+ */
+function automatic logic [31:0] encode_u(
+    input logic [19:0] imm, input logic [4:0] rd, input logic [6:0] opcode
+);
+    return {imm, rd, opcode};
+endfunction
+
+/* imm is the actual jump offset in bytes -- must be even, same reasoning as encode_b. */
+function automatic logic [31:0] encode_j(
+    input int imm, input logic [4:0] rd, input logic [6:0] opcode
+);
+    return {imm[20], imm[10:1], imm[11], imm[19:12], rd, opcode};
+endfunction
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/* Opcodes, for readability at call sites -- avoids repeating raw 7-bit literals. */
+`define OPC_LOAD      7'b0000011
+`define OPC_OP_IMM    7'b0010011
+`define OPC_STORE     7'b0100011
+`define OPC_OP        7'b0110011
+`define OPC_LUI       7'b0110111
+`define OPC_OP_IMM_32 7'b0011011
+`define OPC_OP_32     7'b0111011
+`define OPC_AUIPC     7'b0010111
+`define OPC_JAL       7'b1101111
+`define OPC_JALR      7'b1100111
+`define OPC_BRANCH    7'b1100011
+`define OPC_SYSTEM    7'b1110011
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/* End of file. */


### PR DESCRIPTION
## Summary

First milestone of the RV64IMAC+Zicsr roadmap: a real, verified single-cycle RV64I core, built on this branch's simpler single-module architecture rather than main's pipeline.

- Fixes real bugs in the reused `alu.sv`/`register_file.sv`/`decoder.sv`: SLT/SRA signedness, unmasked shift amounts, inverted regfile write-enable, x0 never hardwired, missing sign-extension on every immediate type (including a 12-vs-13-bit zero-pad bug specific to S-type store offsets), and SLLI/SRLI/SRAI reading garbage shift amounts instead of the actual shift field.
- Widens `alu.sv`/`register_file.sv`/`decoder.sv` to `WORD_SIZE=64` and adds the RV64I-only instructions: `LWU`/`LD`/`SD` and the `*W`/`*IW` word-arithmetic family.
- Adds two new purpose-built memory modules, `imem.sv`/`dmem.sv` — combinational reads with real byte-enable writes, since the existing Wishbone-attached `wb4_sram.sv` is registered (minimum 2-cycle transaction) and can't support single-cycle timing. Real Wishbone integration is a later milestone, not this one.
- `design/core.sv` is a full rewrite: a genuine single-cycle datapath (no FSM) — fetch, decode, execute, memory, and writeback all complete within one clock edge-to-edge cycle.

Out of scope here (later milestones): M/A/C extensions, Zicsr/CSRs, privilege modes, Sv39, UART, JTAG, pipelining, out-of-order.

## Test plan

- [x] `alu_tb.sv` (11 checks) and `register_file_tb.sv` (6 checks) — unit-level, isolated from the core
- [x] `core_alu_ops_tb.sv` (7), `core_upper_imm_tb.sv` (3), `core_load_store_tb.sv` (4), `core_branch_jump_tb.sv` (7), `core_rv64_word_ops_tb.sv` (6) — integration, each targeting a specific regression rather than just "does it run" (negative immediates, the SLT/SRA fixes, the S-type offset bug via an independent load-path cross-check, JALR's LSB-clear, ADDW/SRAW vs their 64-bit equivalents on identical inputs)
- [x] 44/44 checks passing under `iverilog` (WSL)
- [x] `verilator --lint-only -Wall` clean (zero warnings) across the full design

🤖 Generated with [Claude Code](https://claude.com/claude-code)