### PR TITLE
Minimal Wishbone SoC: RAM + UART, hello world over iverilog

### DIFF
--- a/design/core.sv
+++ b/design/core.sv
@@ -10,57 +10,171 @@
 
 
 /*
- * Module: core (single-cycle RV64I)
+ * Module: core (multi-cycle RV64I, Wishbone master)
  *
- * Every instruction completes fetch through writeback within one clock
- * edge-to-edge cycle -- there is no FSM here at all. That's only possible
- * because imem/dmem (below) are purpose-built with combinational reads;
- * see their own header comments for why a Wishbone-attached memory like
- * design/wb4_sram.sv couldn't work here (its ack is a registered output,
- * a minimum 2-edge transaction by construction). Hooking this core up to
- * a real, registered memory system is a later milestone, not this one.
+ * Supersedes the single-cycle version: instead of a combinational-read
+ * imem/dmem pair private to this module, the core is now the SOLE master
+ * on a shared Wishbone bus (see design/wb_addr_decoder.sv,
+ * design/wb4_sram.sv, design/uart_tx.sv) -- instruction fetch and data
+ * access are both real bus transactions now, and both slaves ack one
+ * cycle after being addressed (registered, not combinational). That
+ * multi-cycle reality is why this can no longer be single-cycle: a 3-state
+ * FSM (S_FETCH / S_EXEC / S_MEM) sequences each instruction instead.
  *
- * decoder/alu/register_file are reused as-is (bugs fixed separately, see
- * their own files) rather than re-implemented here -- this module is
- * purely the glue between them: the PC, the control unit that decides
- * what each of them should do for a given decoded instruction, and the
- * muxes that route data between them.
+ * decoder/alu/register_file are reused completely unchanged from the
+ * single-cycle version -- they were already purely combinational glue
+ * with no notion of "cycle" baked in, so nothing about them needed to
+ * change. What's new here is entirely the FSM: WHEN the bus is driven,
+ * and WHEN the results of that already-combinational logic are allowed to
+ * actually commit (register-file write, pc update). See `commit_now`
+ * below -- that one signal is the entire difference between this file and
+ * the single-cycle version's control-flow shape.
  *
- * `INSTR_CODE(name)` (used throughout the control logic below) and every
- * ALU op name (`ADD, `SLTW, etc.) are inherited from decoder.sv's and
- * alu.sv's own `includes -- not re-included here, since both of those
- * modules are necessarily compiled/instantiated below already.
+ * Per-instruction flow:
+ *  S_FETCH: issue a bus read at pc (dword-aligned -- the bus is 64-bit
+ *           wide, so one beat fetches TWO adjacent 32-bit instructions;
+ *           pc[2] selects which half this instruction actually is).
+ *           Wait for ack, latch the 64-bit line, move to S_EXEC.
+ *  S_EXEC:  bus idle. decoder/alu/register_file settle combinationally
+ *           off the latched instruction (exactly the single-cycle
+ *           version's Decode/Control/Execute/Writeback/Next-PC logic,
+ *           verbatim). If this instruction is a load or store, move to
+ *           S_MEM without committing anything yet. Otherwise this is the
+ *           instruction's last cycle: commit (regfile write + pc update)
+ *           on this edge and return to S_FETCH.
+ *  S_MEM:   (loads/stores only) issue a bus read or write at alu_result.
+ *           Wait for ack; on that edge commit (a load's regfile write
+ *           happens HERE, not in S_EXEC, since the loaded value doesn't
+ *           exist yet when S_EXEC ends) and return to S_FETCH.
+ *
+ * Why nothing needs re-latching between S_EXEC and S_MEM: pc doesn't
+ * change until commit_now, and the fetched instruction doesn't change
+ * until the next S_FETCH's ack -- so every combinational signal derived
+ * from them (decoded_instruction, imm_1/imm_2, alu_result, next_pc, ...)
+ * is already stable for the instruction's entire multi-cycle lifetime,
+ * with no extra latching required beyond the one real latch this design
+ * adds (the fetched instruction line itself).
  *
  * Scope: full RV64I base ISA. No M/A/C extensions, no Zicsr/CSRs, no
  * privilege modes, no Sv39, no interrupts/exceptions -- all later
  * milestones. Misaligned access, FENCE, and ECALL are deliberately
  * under-implemented here (see their handling below) for the same reason.
+ * wb_err_i is likewise not acted on -- no trap mechanism exists yet for
+ * it to feed into.
  *
  * Input ports:
  *  clk: Clock.
- *  rst: Synchronous reset (active high) -- resets pc to 0 and clears
+ *  rst: Synchronous reset (active high) -- resets pc, FSM state, and
  *       `halted`. Does NOT reset register/memory contents; the ISA
  *       doesn't require it, and real hardware doesn't guarantee it
  *       either (only the reset vector is architecturally defined).
+ *
+ * Wishbone master port: standard CLASSIC-cycle signal names, written
+ * from this module's (the master's) point of view -- `_o` drives the
+ * bus, `_i` reads it. Connects to design/wb_addr_decoder.sv's CPU-facing
+ * port one-for-one (that module's `_i`/`_o` are the mirror image of
+ * these, as expected for a master/slave pair).
  */
 module core (
     input logic clk,
-    input logic rst
+    input logic rst,
+
+    output logic [31:0] wb_addr_o,
+    output logic [63:0] wb_dat_o,
+    input  logic [63:0] wb_dat_i,
+    output logic [7:0]  wb_sel_o,
+    output logic        wb_we_o,
+    output logic        wb_cyc_o,
+    output logic        wb_stb_o,
+    input  logic        wb_ack_i,
+    /* verilator lint_off UNUSEDSIGNAL */
+    input  logic        wb_err_i
+    /* verilator lint_on UNUSEDSIGNAL */
 );
+
+    /* --------------------------------------------------------------- *
+     * FSM state
+     * --------------------------------------------------------------- */
+
+    typedef enum logic [1:0] {
+        S_FETCH,
+        S_EXEC,
+        S_MEM
+    } state_t;
+
+    state_t state;
+
+    logic [(`WORD_SIZE - 1):0] pc;
+    logic [(`WORD_SIZE - 1):0] next_pc;
+
+    /*
+     * Forward-declared here (driven later, in the Control unit and
+     * PC/halt sections respectively) purely because Icarus Verilog wants
+     * a signal declared before its first use, textually -- unlike the
+     * rest of this file, mem_phase_needed/wb_master_drive genuinely need
+     * to reference them earlier in the file than where they're driven.
+     */
+    logic is_load, is_store;
+    logic halted;
+
+    /*
+     * commit_now: the single edge, per instruction, where the
+     * register-file write and the pc update are allowed to actually
+     * happen. Every other cycle of an instruction's multi-cycle lifetime
+     * (bus wait states, the settle cycle itself) must NOT commit, even
+     * though decoder/alu outputs are sitting there fully formed the
+     * whole time -- reg_write/next_pc are free-running combinational
+     * signals with no notion of "am I allowed to land yet", so this is
+     * the one gate that turns "instruction is decoded" into "instruction
+     * has retired". Non-memory instructions retire at the end of
+     * S_EXEC; loads/stores retire when S_MEM's bus transaction acks.
+     */
+    wire mem_phase_needed = is_load || is_store;
+    wire commit_now = (state == S_EXEC && !mem_phase_needed)
+                    || (state == S_MEM && wb_ack_i);
+
+    always_ff @(posedge clk) begin
+        if (rst) begin
+            state <= S_FETCH;
+        end else begin
+            case (state)
+                S_FETCH: if (wb_ack_i) state <= S_EXEC;
+                S_EXEC:  state <= state_t'(mem_phase_needed ? S_MEM : S_FETCH);
+                S_MEM:   if (wb_ack_i) state <= S_FETCH;
+                default: state <= S_FETCH;
+            endcase
+        end
+    end
 
     /* --------------------------------------------------------------- *
      * Fetch
      * --------------------------------------------------------------- */
 
-    logic [(`WORD_SIZE - 1):0] pc;
-    logic [(`WORD_SIZE - 1):0] next_pc;
+    /*
+     * The bus is 64-bit wide and word-addressed (low 3 address bits
+     * unused, same convention as wb4_sram.sv/wb_addr_decoder.sv), but
+     * instructions are 32-bit -- one fetch beat brings in two of them.
+     * pc[2] (always a real address bit for a 4-byte-aligned pc) picks
+     * which half is the one actually being executed; pc[1:0] are always
+     * 0 and play no role here.
+     */
+    logic [63:0] instr_line_q;
+    always_ff @(posedge clk) begin
+        if (state == S_FETCH && wb_ack_i)
+            instr_line_q <= wb_dat_i;
+    end
 
     logic [(`INSTR_SIZE - 1):0] instruction;
+    assign instruction = pc[2] ? instr_line_q[63:32] : instr_line_q[31:0];
 
-    imem imem0 (
-        .i_addr(pc),
-        .o_instruction(instruction)
-    );
+    /*
+     * Dword-aligned fetch address, precomputed as a plain wire rather
+     * than inline inside wb_master_drive's always_comb below -- same
+     * "Icarus doesn't fully support constant selects inside always_*
+     * processes" reason as everywhere else this pattern appears in this
+     * file.
+     */
+    wire [31:0] fetch_addr = {pc[31:3], 3'b0};
 
     /* --------------------------------------------------------------- *
      * Decode
@@ -79,7 +193,9 @@ module core (
      * decoder uses to produce o_imm_1/o_imm_2) but it isn't a real
      * combinational cycle: the *_sel outputs depend ONLY on
      * i_instruction inside decoder, never on the data that comes back.
-     * It settles in zero simulated time as a plain feedforward chain.
+     * It settles in zero simulated time as a plain feedforward chain --
+     * and since `instruction` is latched (stable for the whole
+     * instruction), so is everything downstream of it here.
      */
     decoder decoder0 (
         .i_instruction(instruction),
@@ -141,9 +257,10 @@ module core (
      * Control unit
      * --------------------------------------------------------------- */
 
-    wire is_auipc = (decoded_instruction == `INSTR_CODE(AUIPC));
-    wire is_jal   = (decoded_instruction == `INSTR_CODE(JAL));
-    wire is_jalr  = (decoded_instruction == `INSTR_CODE(JALR));
+    wire is_auipc  = (decoded_instruction == `INSTR_CODE(AUIPC));
+    wire is_jal    = (decoded_instruction == `INSTR_CODE(JAL));
+    wire is_jalr   = (decoded_instruction == `INSTR_CODE(JALR));
+    wire is_ebreak = (decoded_instruction == `INSTR_CODE(EBREAK));
 
     /*
      * ADDW/SUBW/ADDIW reuse the plain ADD/SUB ALU ops on full 64-bit
@@ -209,7 +326,6 @@ module core (
         endcase
     end: alu_op_sel
 
-    logic is_load, is_store;
     logic [1:0] mem_size;
     logic load_signed;
     always_comb begin: mem_control
@@ -237,7 +353,10 @@ module core (
      * reg_write: computed by excluding the SHORT list of instructions
      * that don't write rd, rather than enumerating the long list that
      * does -- fewer places to accidentally miss an entry when a future
-     * milestone adds more instructions.
+     * milestone adds more instructions. Gated by commit_now (see its own
+     * comment above) so this only actually reaches regfile0 on the one
+     * edge each instruction is allowed to retire, not throughout the
+     * whole multi-cycle window it happens to be decoded.
      */
     logic reg_write_ctrl;
     always_comb begin: reg_write_control
@@ -252,7 +371,7 @@ module core (
                 reg_write_ctrl = 1'b1;
         endcase
     end: reg_write_control
-    assign reg_write = reg_write_ctrl;
+    assign reg_write = reg_write_ctrl && commit_now;
 
     /* --------------------------------------------------------------- *
      * Execute
@@ -308,33 +427,43 @@ module core (
      * --------------------------------------------------------------- */
 
     /*
-     * alu_result does double duty here: it's "the ALU's answer" for
-     * every non-memory instruction, and "the memory address" for
+     * alu_result does triple duty here: it's "the ALU's answer" for
+     * every non-memory instruction, "the memory address" for
      * loads/stores (base register + offset, computed by the same adder
-     * via the operand muxing above) -- deliberate reuse of one datapath,
-     * not a coincidence.
+     * via the operand muxing above), AND the source of the bus's
+     * dword-aligned address plus the byte-lane shift amount below --
+     * deliberate reuse of one datapath, not a coincidence.
+     *
+     * The bus (see wb4_sram.sv/uart_tx.sv) is word-granular: address
+     * bits [2:0] aren't decoded by either slave, and sub-dword access
+     * width instead comes from which of the 8 sel_o lanes are asserted.
+     * So a byte/half/word access needs its size turned into a lane mask,
+     * shifted into position by the address's low 3 bits -- same
+     * technique design/dmem.sv used for its own byte-enable writes.
      */
-    logic [(`WORD_SIZE - 1):0] dmem_rdata;
-    dmem dmem0 (
-        .i_clk(clk),
-        .i_addr(alu_result),
-        .i_size(mem_size),
-        .i_write_enable(is_store),
-        .i_write_data(imm_2),  // rs2 -- OUTPUT_S_TYPE_INSTR puts the store's source value here
-        .o_read_data(dmem_rdata)
-    );
+    wire [7:0] mem_size_mask = (mem_size == 2'b00) ? 8'b0000_0001 :
+                                (mem_size == 2'b01) ? 8'b0000_0011 :
+                                (mem_size == 2'b10) ? 8'b0000_1111 :
+                                                       8'b1111_1111;
+    wire [7:0] mem_sel = mem_size_mask << alu_result[2:0];
 
-    /* Shift dmem's line so the byte(s) we actually want start at bit 0. */
-    wire [(`WORD_SIZE - 1):0] dmem_rdata_shifted = dmem_rdata >> (alu_result[2:0] * 8);
+    /* Dword-aligned memory address -- same precompute-outside-always_comb reason as fetch_addr above. */
+    wire [31:0] mem_addr = {alu_result[31:3], 3'b0};
+
+    /* Store data, pre-shifted into the byte lane(s) it'll land in. */
+    wire [(`WORD_SIZE - 1):0] mem_wdata = imm_2 << (alu_result[2:0] * 8);
+
+    /* Read response, shifted back down so the wanted byte(s) start at bit 0. */
+    wire [(`WORD_SIZE - 1):0] mem_rdata_shifted = wb_dat_i >> (alu_result[2:0] * 8);
 
     /*
      * Precomputed slices, not inline inside load_format's case statement
      * below -- Icarus Verilog doesn't fully support constant selects
      * inside always_* processes (same reason as alu.sv's shamt_masked).
      */
-    wire [7:0]  load_byte  = dmem_rdata_shifted[7:0];
-    wire [15:0] load_half  = dmem_rdata_shifted[15:0];
-    wire [31:0] load_word  = dmem_rdata_shifted[31:0];
+    wire [7:0]  load_byte  = mem_rdata_shifted[7:0];
+    wire [15:0] load_half  = mem_rdata_shifted[15:0];
+    wire [31:0] load_word  = mem_rdata_shifted[31:0];
     /* Sign bits, precomputed too -- same reason (also used inside a replication below). */
     wire load_byte_sign = load_byte[7];
     wire load_half_sign = load_half[15];
@@ -349,9 +478,78 @@ module core (
                                             : {48'b0, load_half};
             2'b10: load_data = load_signed ? {{32{load_word_sign}}, load_word}
                                             : {32'b0, load_word};
-            default: load_data = dmem_rdata_shifted; // 2'b11: doubleword, no extension needed
+            default: load_data = mem_rdata_shifted; // 2'b11: doubleword, no extension needed
         endcase
     end: load_format
+
+    /* --------------------------------------------------------------- *
+     * Wishbone master: bus driving
+     * --------------------------------------------------------------- */
+
+    /*
+     * Idle by default (every field), overridden per-state below -- keeps
+     * this a clean combinational mux with no inferred latches, same
+     * defaults-then-case idiom already used for mem_control/
+     * reg_write_control above. S_EXEC drives nothing: the bus is only
+     * needed to fetch (S_FETCH) or to access memory (S_MEM), never
+     * during the settle-and-decode cycle in between.
+     *
+     * Both S_FETCH and S_MEM additionally gate cyc_o/stb_o with
+     * !wb_ack_i, NOT just `state == S_*` -- this is load-bearing, not
+     * decoration. `state` only updates on the NEXT clock edge after
+     * wb_ack_i is observed (see the state always_ff below), so for the
+     * entire cycle in between -- from the moment the slave's registered
+     * ack_o first becomes 1 to the edge core.sv's FSM actually reacts to
+     * it -- cyc_o/stb_o would otherwise still read as asserted. A slave
+     * that simply does `if (cyc_i && stb_i) <act once, ack>` (both
+     * wb4_sram.sv and uart_tx.sv do exactly this, and correctly so --
+     * nothing about the spec obligates a slave to guess whether a
+     * still-asserted cyc/stb is a new request or the master being slow
+     * to notice the old one) would then see cyc/stb still high on that
+     * extra cycle and serve the SAME request a second time. Found via
+     * this exact symptom: the UART printed "HH" for a single-byte write.
+     * Gating with !wb_ack_i drops cyc_o/stb_o combinationally the moment
+     * ack_i is observed, so the slave sees the request deasserted before
+     * it would ever re-fire -- standard Wishbone master practice, and
+     * the same root cause (not the same fix -- that one patched a
+     * testbench's own master-role loop) as the wb_cycle ack-timing bug
+     * in wb4_sram_tb.sv/uart_tx_tb.sv.
+     */
+    always_comb begin: wb_master_drive
+        wb_cyc_o  = 1'b0;
+        wb_stb_o  = 1'b0;
+        wb_we_o   = 1'b0;
+        wb_addr_o = 32'b0;
+        wb_dat_o  = 64'b0;
+        wb_sel_o  = 8'b0;
+        case (state)
+            S_FETCH: begin
+                /*
+                 * Once halted, never issue another fetch -- see the
+                 * halt-latch comment below for why parking here (rather
+                 * than, say, forcing state to hold) is sufficient to
+                 * freeze the whole core.
+                 */
+                if (!halted && !wb_ack_i) begin
+                    wb_cyc_o  = 1'b1;
+                    wb_stb_o  = 1'b1;
+                    wb_addr_o = fetch_addr;
+                    wb_sel_o  = 8'hFF; // don't-care for a read; full line for clarity
+                end
+            end
+            S_MEM: begin
+                if (!wb_ack_i) begin
+                    wb_cyc_o  = 1'b1;
+                    wb_stb_o  = 1'b1;
+                    wb_we_o   = is_store;
+                    wb_addr_o = mem_addr;
+                    wb_sel_o  = mem_sel;
+                    wb_dat_o  = mem_wdata;
+                end
+            end
+            default: ; // S_EXEC: bus idle
+        endcase
+    end: wb_master_drive
 
     /* --------------------------------------------------------------- *
      * Writeback
@@ -394,26 +592,32 @@ module core (
 
     /*
      * EBREAK latches `halted` and freezes pc -- the only piece of
-     * "extra" state in this design, beyond pc itself and the two
-     * memories' write ports. Freezing pc (rather than letting it run on
-     * into whatever follows EBREAK) is a deliberate choice: once
-     * halted, the core would otherwise keep fetching and "executing"
-     * subsequent memory contents, which is harmless if that's zeroed
-     * (decodes as INVALID, a no-op) but isn't guaranteed to be zero in
-     * every testbench. Testbenches watch this signal via a hierarchical
-     * reference (e.g. dut.halted) to know when a test program has
-     * finished running, without guessing a cycle count.
+     * "extra" state in this design, beyond pc/state/instr_line_q. Both
+     * commit only on commit_now (EBREAK is never a load/store, so it
+     * always retires at the end of S_EXEC). pc is deliberately excluded
+     * from advancing on the SAME edge halted is set (`!is_ebreak` below)
+     * -- otherwise pc would jump past EBREAK on the very edge that's
+     * supposed to freeze it. After that edge, state parks in S_FETCH
+     * forever (the bus-driving block above stops issuing fetches once
+     * halted), so commit_now can never become true again and both
+     * registers stay frozen with no further gating needed.
+     *
+     * Testbenches watch `halted` via a hierarchical reference (e.g.
+     * dut.halted) to know when a test program has finished running,
+     * without guessing a cycle count.
      */
-    logic halted;
     always_ff @(posedge clk) begin
         if (rst)
             halted <= 1'b0;
-        else if (decoded_instruction == `INSTR_CODE(EBREAK))
+        else if (commit_now && is_ebreak)
             halted <= 1'b1;
     end
 
     always_ff @(posedge clk) begin
-        pc <= rst ? '0 : (halted ? pc : next_pc);
+        if (rst)
+            pc <= '0;
+        else if (commit_now && !is_ebreak)
+            pc <= next_pc;
     end
 
 endmodule

--- a/design/soc.sv
+++ b/design/soc.sv
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Module: soc
+ *
+ * Top-level integration: core (Wishbone master) <-> wb_addr_decoder <->
+ * {wb4_sram, uart_tx}. Exactly the wiring already proven in
+ * testbench/core_wb_tb.sv, promoted to a real module now that all four
+ * pieces are independently verified -- this file adds no new logic of
+ * its own, only the connections between them.
+ *
+ * wb4_sram is instantiated at its default num_words (4096, 32KB) --
+ * unlike core_wb_tb.sv's deliberately small test instance, this is the
+ * real memory map wb_addr_decoder.sv's address split (addr_i[15]) is
+ * derived from; see that module's own header comment for why the two
+ * aren't independent.
+ *
+ * No UART pin exists at this level (or anywhere in this design) -- see
+ * uart_tx.sv's header for why: this milestone's UART "transmits" via
+ * $write in simulation, not real serial timing, so there is nothing for
+ * a top-level pin to carry. clk/rst are this module's only ports.
+ */
+module soc (
+    input logic clk,
+    input logic rst
+);
+
+    logic [31:0] wb_addr;
+    logic [63:0] wb_dat_m2s, wb_dat_s2m;
+    logic [7:0]  wb_sel;
+    logic        wb_we, wb_cyc, wb_stb, wb_ack, wb_err;
+
+    core core0 (
+        .clk(clk), .rst(rst),
+        .wb_addr_o(wb_addr), .wb_dat_o(wb_dat_m2s), .wb_dat_i(wb_dat_s2m),
+        .wb_sel_o(wb_sel), .wb_we_o(wb_we), .wb_cyc_o(wb_cyc), .wb_stb_o(wb_stb),
+        .wb_ack_i(wb_ack), .wb_err_i(wb_err)
+    );
+
+    logic [31:0] ram_addr, uart_addr;
+    logic [63:0] ram_dat_o, ram_dat_i, uart_dat_o, uart_dat_i;
+    logic [7:0]  ram_sel, uart_sel;
+    logic        ram_we, ram_cyc, ram_stb, ram_ack, ram_err;
+    logic        uart_we, uart_cyc, uart_stb, uart_ack, uart_err;
+
+    wb_addr_decoder decoder0 (
+        .clk(clk), .rst(rst),
+        .addr_i(wb_addr), .dat_i(wb_dat_m2s), .dat_o(wb_dat_s2m), .sel_i(wb_sel),
+        .we_i(wb_we), .cyc_i(wb_cyc), .stb_i(wb_stb), .ack_o(wb_ack), .err_o(wb_err),
+        .ram_addr_o(ram_addr), .ram_dat_o(ram_dat_o), .ram_dat_i(ram_dat_i),
+        .ram_sel_o(ram_sel), .ram_we_o(ram_we), .ram_cyc_o(ram_cyc),
+        .ram_stb_o(ram_stb), .ram_ack_i(ram_ack), .ram_err_i(ram_err),
+        .uart_addr_o(uart_addr), .uart_dat_o(uart_dat_o), .uart_dat_i(uart_dat_i),
+        .uart_sel_o(uart_sel), .uart_we_o(uart_we), .uart_cyc_o(uart_cyc),
+        .uart_stb_o(uart_stb), .uart_ack_i(uart_ack), .uart_err_i(uart_err)
+    );
+
+    wb4_sram sram0 (
+        .clk(clk), .rst(rst),
+        .addr_i(ram_addr), .dat_i(ram_dat_o), .dat_o(ram_dat_i), .sel_i(ram_sel),
+        .ack_o(ram_ack), .err_o(ram_err), .cyc_i(ram_cyc), .stb_i(ram_stb), .we_i(ram_we)
+    );
+
+    uart_tx uart0 (
+        .clk(clk), .rst(rst),
+        .addr_i(uart_addr), .dat_i(uart_dat_o), .dat_o(uart_dat_i), .sel_i(uart_sel),
+        .ack_o(uart_ack), .err_o(uart_err), .cyc_i(uart_cyc), .stb_i(uart_stb), .we_i(uart_we)
+    );
+
+endmodule

--- a/design/uart_tx.sv
+++ b/design/uart_tx.sv
@@ -1,0 +1,122 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Module: uart_tx
+ *
+ * A real, addressable Wishbone-slave peripheral, not a testbench-only
+ * shortcut -- deliberately minimal for this milestone (transmit only, no
+ * baud-rate timing) but structured as something later work can grow real
+ * serial timing into, rather than something to throw away.
+ *
+ * Internally this "transmits" via $write immediately on a register write
+ * -- there is no bit-banged serial output and no baud-rate model at all.
+ * That's a deliberate simplification, not an oversight: the goal for
+ * this milestone is a real program printing real characters in an
+ * iverilog run, not hardware-accurate timing.
+ *
+ * Same registered, 1-wait-state ack timing as wb4_sram.sv, purely for
+ * bus uniformity -- the CPU's wait state doesn't need to know or care
+ * which slave it's talking to. A combinational/zero-wait UART would also
+ * be legal Wishbone and work correctly with core.sv's FSM (which just
+ * watches ack_i each edge regardless of latency), but mixed timing
+ * across slaves on one bus is more surface area to get wrong for no
+ * benefit here.
+ *
+ * Register map (only addr_i[3] is decoded -- everything routed here by
+ * wb_addr_decoder.sv already has addr_i[15] set, nothing else needs
+ * checking):
+ *   0x8000  TX_DATA    write: low byte is "printed" immediately.
+ *                      read: always 0.
+ *   0x8008  TX_STATUS  read-only. bit 0 = TX_READY, hardwired 1 -- this
+ *                      model has no timing, so it's trivially always
+ *                      ready. Exists so firmware can use a realistic
+ *                      poll-then-write pattern even though polling
+ *                      never actually has to wait yet.
+ */
+module uart_tx (
+    input logic clk,
+    input logic rst,
+
+    /*
+     * Only addr_i[3] (register select), dat_i[7:0] (the byte to print),
+     * and sel_i[0] (byte-enable for that same byte) are used -- this is
+     * a byte-wide peripheral behind a 64-bit bus, so the rest of these
+     * ports' bits are genuinely don't-care by design, same pattern
+     * already used for wb4_sram.sv's/dmem.sv's address ports.
+     */
+    /* verilator lint_off UNUSEDSIGNAL */
+    input  logic [31:0] addr_i,
+    input  logic [63:0] dat_i,
+    input  logic [7:0]  sel_i,
+    /* verilator lint_on UNUSEDSIGNAL */
+    output logic [63:0] dat_o,
+
+    output logic ack_o,
+    output logic err_o,
+    input  logic cyc_i,
+    input  logic stb_i,
+    input  logic we_i
+);
+    localparam TX_DATA_SEL   = 1'b0;
+    localparam TX_STATUS_SEL = 1'b1;
+
+    /*
+     * Simulation-only capture of every transmitted character, for
+     * testbench-side checking via a hierarchical reference (e.g.
+     * dut.uart0.tx_history) -- same spirit as the single-cycle
+     * milestone's core_*_tb.sv tests reading dut.regfile0.gp_registers
+     * directly. A fixed array + count, not a queue/string, to stay on
+     * constructs already proven to compile cleanly in this codebase's
+     * iverilog flow rather than reach for new ones.
+     */
+    localparam TX_HISTORY_DEPTH = 256;
+    /* verilator lint_off UNUSEDSIGNAL */
+    logic [7:0] tx_history [0:(TX_HISTORY_DEPTH - 1)];
+    /* verilator lint_on UNUSEDSIGNAL */
+    /*
+     * One bit wider than strictly needed to INDEX the array (8 bits
+     * covers indices 0-255) so this can also represent the value 256
+     * itself -- i.e. "the buffer is now full" -- without wrapping back
+     * to 0. The tx_history_count < TX_HISTORY_DEPTH guard below means
+     * the array is only ever actually indexed with values 0-255, so the
+     * 9th bit is dropped explicitly (tx_history_count[7:0]) at the one
+     * place that indexes the array, rather than left as an implicit
+     * (and lint-flagged) truncation.
+     */
+    logic [$clog2(TX_HISTORY_DEPTH):0] tx_history_count;
+
+    always @(posedge clk) begin
+        if (rst) begin
+            ack_o <= 1'b0;
+            err_o <= 1'b0;
+            dat_o <= 64'b0;
+            tx_history_count <= '0;
+        end else if (cyc_i && stb_i) begin
+            if (we_i && (addr_i[3] == TX_DATA_SEL) && sel_i[0]) begin
+                $write("%c", dat_i[7:0]);
+                $fflush;
+                if (tx_history_count < TX_HISTORY_DEPTH) begin
+                    tx_history[tx_history_count[7:0]] <= dat_i[7:0];
+                    tx_history_count <= tx_history_count + 1'b1;
+                end
+            end
+            dat_o <= (addr_i[3] == TX_STATUS_SEL) ? 64'h1 : 64'h0;
+            ack_o <= 1'b1;
+            err_o <= 1'b0;
+        end else begin
+            ack_o <= 1'b0;
+            err_o <= 1'b0;
+        end
+    end
+    /*
+     * err_o is intentionally never asserted -- no error conditions are
+     * defined for this minimal peripheral (e.g. no address-range check
+     * the way wb4_sram.sv has one, since wb_addr_decoder.sv is the only
+     * thing that ever routes a request here and it already only does so
+     * for addresses with bit 15 set).
+     */
+
+endmodule

--- a/design/uart_tx_tb.sv
+++ b/design/uart_tx_tb.sv
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Testbench: uart_tx
+ *
+ * Drives the Wishbone port directly. Console output ("Hi" appearing
+ * literally in the run's stdout) is a visual sanity check, not what's
+ * asserted on -- the checked behavior is tx_history[]/tx_history_count,
+ * which is exactly what that capture mechanism exists for.
+ */
+module uart_tx_tb;
+
+    logic clk = 0;
+    always #5 clk = ~clk;
+    logic rst = 1;
+
+    logic [31:0] addr;
+    logic [63:0] dat_i, dat_o;
+    logic [7:0]  sel;
+    logic        ack, err, cyc, stb, we;
+
+    uart_tx dut (
+        .clk(clk), .rst(rst),
+        .addr_i(addr), .dat_i(dat_i), .dat_o(dat_o), .sel_i(sel),
+        .ack_o(ack), .err_o(err), .cyc_i(cyc), .stb_i(stb), .we_i(we)
+    );
+
+    int pass_count = 0;
+    int fail_count = 0;
+    task automatic check(string name, logic [63:0] actual, logic [63:0] expected);
+        if (actual === expected) begin
+            pass_count++;
+            $display("PASS: %s", name);
+        end else begin
+            fail_count++;
+            $display("FAIL: %s -- expected %h, got %h", name, expected, actual);
+        end
+    endtask
+
+    /*
+     * #1 after each @(posedge clk) before checking ack is required, not
+     * decorative: ack_o is updated via <= in the DUT's clocked block, so
+     * it only becomes visible in the NBA region AFTER this same edge's
+     * active region finishes. Checking ack immediately upon resuming
+     * from @(posedge clk) reads its PRE-edge value, one edge stale --
+     * which would make this loop exit one edge late, leaving cyc/stb
+     * asserted for an extra edge and causing the DUT to process the
+     * same transaction a second time (silently harmless for an
+     * idempotent memory read/write, but not for a side-effecting
+     * peripheral like this one -- this bug was found via a duplicated
+     * character in this exact testbench, then fixed here).
+     */
+    task automatic wb_cycle(logic [31:0] a, logic [63:0] d, logic [7:0] s, logic w);
+        @(negedge clk);
+        addr = a; dat_i = d; sel = s; we = w; cyc = 1; stb = 1;
+        @(posedge clk); #1;
+        while (!ack) begin
+            @(posedge clk); #1;
+        end
+        cyc = 0; stb = 0;
+    endtask
+
+    initial begin
+        cyc = 0; stb = 0; we = 0; addr = 0; dat_i = 0; sel = 8'h00;
+        @(posedge clk); #1;
+        rst = 0;
+
+        // Write "Hi" -- prints live to console.
+        wb_cycle(32'h8000, 64'h48, 8'h01, 1'b1); // 'H'
+        wb_cycle(32'h8000, 64'h69, 8'h01, 1'b1); // 'i'
+        check("two characters captured", {56'b0, dut.tx_history_count}, 64'd2);
+        check("history[0] == 'H'", {56'b0, dut.tx_history[0]}, 64'h48);
+        check("history[1] == 'i'", {56'b0, dut.tx_history[1]}, 64'h69);
+
+        // Write with byte-enable OFF (sel[0]=0) -- must not capture.
+        wb_cycle(32'h8000, 64'hFF, 8'h00, 1'b1);
+        check("write without sel[0] is ignored", {56'b0, dut.tx_history_count}, 64'd2);
+
+        // TX_STATUS always reads ready.
+        wb_cycle(32'h8008, 64'h0, 8'h00, 1'b0);
+        check("TX_STATUS reads ready (1)", dat_o, 64'h1);
+
+        // TX_DATA reads back 0.
+        wb_cycle(32'h8000, 64'h0, 8'h00, 1'b0);
+        check("TX_DATA reads 0", dat_o, 64'h0);
+
+        $display("");
+        $display("uart_tx_tb: %0d passed, %0d failed", pass_count, fail_count);
+        if (fail_count > 0) $display("uart_tx_tb: FAILURES PRESENT");
+        $finish;
+    end
+
+endmodule

--- a/design/wb4_sram.sv
+++ b/design/wb4_sram.sv
@@ -13,8 +13,15 @@
 /*
  * Module: Internal SRAM With Wishbone BUS
  *
+ * Widened to 64-bit data (was 32) so LD/SD complete as single-beat
+ * accesses over the SoC's Wishbone bus -- see design/core.sv's header
+ * comment for why the bus is 64-bit here. Byte-granularity writes now
+ * need an explicit sel_i (SB/SH/SW write less than the full 8-byte line);
+ * core.sv computes the mask/shift (same technique as design/dmem.sv's
+ * write_port block) and this module just does the lane-gated write.
+ *
  * Parameters:
- *  num_words: Number of words in the memory (default = 4096).
+ *  num_words: Number of 64-bit words in the memory (default = 4096, 32KB).
  *
  */
 module wb4_sram #(
@@ -24,9 +31,19 @@ module wb4_sram #(
     input logic rst,
 
     // Wishbone signals
+    /*
+     * Bits [2:0] (the byte offset within an 8-byte word) are genuinely
+     * unused -- this module only supports word-granularity addressing;
+     * per-byte write granularity comes from sel_i, not from low address
+     * bits. Same intentional-narrowing pattern as design/dmem.sv's own
+     * i_addr, silenced there for the same reason.
+     */
+    /* verilator lint_off UNUSEDSIGNAL */
     input  logic [31:0] addr_i,
-    input  logic [31:0] dat_i,
-    output logic [31:0] dat_o,
+    /* verilator lint_on UNUSEDSIGNAL */
+    input  logic [63:0] dat_i,
+    output logic [63:0] dat_o,
+    input  logic [7:0]  sel_i,
 
     output logic ack_o,
     output logic err_o,
@@ -34,34 +51,61 @@ module wb4_sram #(
     input logic stb_i,
     input logic we_i
 );
-    reg [31:0] memory [0:(num_words - 1)];
+    reg [63:0] memory [0:(num_words - 1)];
 
-    // For address calculation
+    // For address calculation. Each word is now 8 bytes (3 byte-offset
+    // bits), not 4 (2 bits) -- word_addr/addr_valid's slices shift by one
+    // bit accordingly versus the 32-bit version this replaced.
     localparam ADDR_WIDTH = $clog2(num_words);
     wire [ADDR_WIDTH-1:0] word_addr;
     wire addr_valid;
 
+    /*
+     * Simulation-only zero-fill, same reasoning and same convention as
+     * imem.sv/dmem.sv/register_file.sv: real hardware has no defined
+     * power-up memory state, but zeroing here keeps waveform/$display
+     * output readable, and matters more here than for those modules --
+     * this is the memory real firmware actually loads into via
+     * $readmemh below, and $readmemh only writes the addresses the hex
+     * file actually specifies, leaving everything else at whatever the
+     * array started as. Applied before $readmemh so a real firmware
+     * load still overwrites the addresses it covers.
+     */
+    integer init_i;
     initial begin
+        for (init_i = 0; init_i < num_words; init_i = init_i + 1)
+            memory[init_i] = '0;
         $readmemh("../firmware/crt0.hex", memory);
     end
 
-    assign word_addr = addr_i[ADDR_WIDTH+1:2]; // Byte to word address
-    assign addr_valid = (addr_i[31:ADDR_WIDTH+2] == 0); // Check upper bits are 0
+    assign word_addr = addr_i[ADDR_WIDTH+2:3]; // Byte to 8-byte-word address
+    assign addr_valid = (addr_i[31:ADDR_WIDTH+3] == 0); // Check upper bits are 0
 
     always @(posedge clk) begin
         if (rst)
         begin
             ack_o <= 1'b0;
             err_o <= 1'b0;
-            dat_o <= 32'b0;
-        end 
+            dat_o <= 64'b0;
+        end
         else
         begin
             if (cyc_i && stb_i) begin
                 if (addr_valid) begin
                     if (we_i)
                     begin
-                        memory[word_addr] <= dat_i;
+                        /*
+                         * Lane-gated write, one bit of sel_i per byte.
+                         * Variable-indexed +: part-select, not a constant
+                         * bit-select -- see dmem.sv's write_port for why
+                         * (Icarus doesn't fully support constant selects
+                         * inside always_* processes; this form sidesteps
+                         * that entirely rather than working around it).
+                         */
+                        for (int lane = 0; lane < 8; lane = lane + 1) begin
+                            if (sel_i[lane])
+                                memory[word_addr][(8*lane) +: 8] <= dat_i[(8*lane) +: 8];
+                        end
                     end
                     else
                     begin
@@ -69,13 +113,13 @@ module wb4_sram #(
                     end
                     ack_o <= 1'b1;
                     err_o <= 1'b0;
-                end 
+                end
                 else
                 begin
                     ack_o <= 1'b0;
                     err_o <= 1'b1;
                 end
-            end 
+            end
             else
             begin
                 ack_o <= 1'b0;

--- a/design/wb4_sram_tb.sv
+++ b/design/wb4_sram_tb.sv
@@ -1,0 +1,114 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+`include "defaults/defaults.sv"
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Testbench: wb4_sram (post-widening to 64-bit + sel_i)
+ *
+ * Drives the Wishbone port directly -- no core.sv involved. Covers a
+ * full round-trip write/read and, specifically, that a partial
+ * byte-enable write leaves the other lanes of the same line untouched
+ * (the actual new behavior this edit added).
+ */
+module wb4_sram_tb;
+
+    logic clk = 0;
+    always #5 clk = ~clk;
+    logic rst = 1;
+
+    logic [31:0] addr;
+    logic [63:0] dat_i, dat_o;
+    logic [7:0]  sel;
+    logic        ack, err, cyc, stb, we;
+
+    wb4_sram #(.num_words(64)) dut (
+        .clk(clk), .rst(rst),
+        .addr_i(addr), .dat_i(dat_i), .dat_o(dat_o), .sel_i(sel),
+        .ack_o(ack), .err_o(err), .cyc_i(cyc), .stb_i(stb), .we_i(we)
+    );
+
+    int pass_count = 0;
+    int fail_count = 0;
+    task automatic check(string name, logic [63:0] actual, logic [63:0] expected);
+        if (actual === expected) begin
+            pass_count++;
+            $display("PASS: %s", name);
+        end else begin
+            fail_count++;
+            $display("FAIL: %s -- expected %h, got %h", name, expected, actual);
+        end
+    endtask
+
+    /*
+     * Issue one WB transaction and wait for ack, mirroring core.sv's own
+     * "hold the request, advance on ack" convention. The #1 after each
+     * @(posedge clk) before checking ack is required: ack_o updates via
+     * <= in the DUT's clocked block, only visible in the NBA region
+     * after this edge's active region finishes -- checking immediately
+     * on resuming from @(posedge clk) would read ack one edge stale,
+     * leaving cyc/stb asserted for an extra edge and causing a second,
+     * spurious transaction (silently harmless here since a repeated
+     * identical read/write is idempotent, but the same task shape
+     * caused a real duplicate-write bug in uart_tx_tb.sv, where it
+     * isn't -- fixed in both places).
+     */
+    task automatic wb_cycle(logic [31:0] a, logic [63:0] d, logic [7:0] s, logic w);
+        @(negedge clk);
+        addr = a; dat_i = d; sel = s; we = w; cyc = 1; stb = 1;
+        @(posedge clk); #1;
+        while (!ack) begin
+            @(posedge clk); #1;
+        end
+        cyc = 0; stb = 0;
+    endtask
+
+    initial begin
+        cyc = 0; stb = 0; we = 0; addr = 0; dat_i = 0; sel = 8'h00;
+        @(posedge clk); #1;
+        rst = 0;
+
+        // Full-word write/read round trip.
+        wb_cycle(32'h0, 64'hDEADBEEF_CAFEF00D, 8'hFF, 1'b1);
+        wb_cycle(32'h0, 64'h0, 8'h00, 1'b0);
+        #1;
+        check("full-word round trip", dat_o, 64'hDEADBEEF_CAFEF00D);
+
+        // Partial byte-enable write: only lanes 0-1 (sel=8'h03) get the
+        // new value; lanes 2-7 (already DE AD BE EF CA FE from above)
+        // must stay untouched.
+        wb_cycle(32'h0, 64'h00000000_0000A5A5, 8'h03, 1'b1);
+        wb_cycle(32'h0, 64'h0, 8'h00, 1'b0);
+        #1;
+        check("byte-enable write only touches enabled lanes", dat_o, 64'hDEADBEEF_CAFEA5A5);
+
+        // A different line entirely stays at its power-on-zero value --
+        // proves word_addr's bit-slice isn't accidentally aliasing lines.
+        wb_cycle(32'h8, 64'h0, 8'h00, 1'b0);
+        #1;
+        check("adjacent line unaffected", dat_o, 64'h0);
+
+        // Out-of-range address (num_words=64 -> valid range is 0x000-0x1FF)
+        // must assert err_o, not silently succeed.
+        @(negedge clk);
+        addr = 32'h1000; dat_i = 64'h0; sel = 8'h00; we = 0; cyc = 1; stb = 1;
+        @(posedge clk); #1;
+        while (!ack && !err) begin
+            @(posedge clk); #1;
+        end
+        check("out-of-range address asserts err_o", {63'b0, err}, 64'd1);
+        cyc = 0; stb = 0;
+
+        $display("");
+        $display("wb4_sram_tb: %0d passed, %0d failed", pass_count, fail_count);
+        if (fail_count > 0) $display("wb4_sram_tb: FAILURES PRESENT");
+        $finish;
+    end
+
+endmodule

--- a/design/wb_addr_decoder.sv
+++ b/design/wb_addr_decoder.sv
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Module: wb_addr_decoder
+ *
+ * Routes the CPU's single Wishbone master port to one of two slaves --
+ * design/wb4_sram.sv (RAM) or design/uart_tx.sv (UART) -- based on
+ * address. One master, two fixed slaves: hand-written rather than a
+ * general N-slave interconnect, since that generality isn't needed here.
+ *
+ * Address map: RAM occupies 0x0000_0000-0x0000_7FFF (wb4_sram.sv's
+ * default num_words=4096 x 8 bytes/word = 32KB), UART is anything with
+ * bit 15 set (0x8000 upward). Since RAM's size is a power of two
+ * starting at address 0, "address >= 0x8000" and "bit 15 set" are the
+ * same condition -- this is a single bit test, not a shortcut that skips
+ * a real range compare. NB: this bit position is DERIVED from wb4_sram's
+ * num_words parameter, not independent of it -- if that default ever
+ * changes, this decode bit needs revisiting too.
+ *
+ * The "remember which slave" problem: both slaves are registered
+ * (1-wait-state) Wishbone slaves, so a response arrives one cycle after
+ * the request that triggered it -- by the time ack_i/dat_i actually need
+ * routing back to the CPU, addr_i may already reflect a *different*,
+ * newer request (or none). So which slave an outstanding transaction
+ * belongs to is latched at the moment the request is issued
+ * (sel_uart_q), not re-derived from addr_i when the response shows up.
+ */
+module wb_addr_decoder (
+    input logic clk,
+    input logic rst,
+
+    // CPU-facing port -- this module is a slave from the CPU's side.
+    input  logic [31:0] addr_i,
+    input  logic [63:0] dat_i,
+    output logic [63:0] dat_o,
+    input  logic [7:0]  sel_i,
+    input  logic        we_i,
+    input  logic        cyc_i,
+    input  logic        stb_i,
+    output logic        ack_o,
+    output logic        err_o,
+
+    // RAM-facing port -- this module is the master here.
+    output logic [31:0] ram_addr_o,
+    output logic [63:0] ram_dat_o,
+    input  logic [63:0] ram_dat_i,
+    output logic [7:0]  ram_sel_o,
+    output logic        ram_we_o,
+    output logic        ram_cyc_o,
+    output logic        ram_stb_o,
+    input  logic        ram_ack_i,
+    input  logic        ram_err_i,
+
+    // UART-facing port.
+    output logic [31:0] uart_addr_o,
+    output logic [63:0] uart_dat_o,
+    input  logic [63:0] uart_dat_i,
+    output logic [7:0]  uart_sel_o,
+    output logic        uart_we_o,
+    output logic        uart_cyc_o,
+    output logic        uart_stb_o,
+    input  logic        uart_ack_i,
+    input  logic        uart_err_i
+);
+    wire sel_uart = addr_i[15];
+
+    /*
+     * Gate cyc/stb per slave; broadcast everything else (addr/dat/sel/we)
+     * to both -- harmless, since a slave with cyc=0 ignores the rest of
+     * the bus regardless of what's sitting on it.
+     */
+    assign ram_cyc_o  = cyc_i && !sel_uart;
+    assign ram_stb_o  = stb_i && !sel_uart;
+    assign uart_cyc_o = cyc_i && sel_uart;
+    assign uart_stb_o = stb_i && sel_uart;
+
+    assign ram_addr_o  = addr_i;
+    assign uart_addr_o = addr_i;
+    assign ram_dat_o   = dat_i;
+    assign uart_dat_o  = dat_i;
+    assign ram_sel_o   = sel_i;
+    assign uart_sel_o  = sel_i;
+    assign ram_we_o    = we_i;
+    assign uart_we_o   = we_i;
+
+    /*
+     * Latched at the cycle a request is actually issued (cyc_i && stb_i),
+     * held until the next request overwrites it -- see the module header
+     * for why this can't just re-check addr_i when the response arrives.
+     */
+    logic sel_uart_q;
+    always_ff @(posedge clk) begin
+        if (rst)
+            sel_uart_q <= 1'b0;
+        else if (cyc_i && stb_i)
+            sel_uart_q <= sel_uart;
+    end
+
+    assign ack_o = sel_uart_q ? uart_ack_i : ram_ack_i;
+    assign err_o = sel_uart_q ? uart_err_i : ram_err_i;
+    assign dat_o = sel_uart_q ? uart_dat_i : ram_dat_i;
+endmodule

--- a/design/wb_addr_decoder_tb.sv
+++ b/design/wb_addr_decoder_tb.sv
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Testbench: wb_addr_decoder
+ *
+ * The decoder is tested in isolation -- no real wb4_sram/uart_tx
+ * instances. Instead this testbench models two trivial fake slaves
+ * directly (each a 1-wait-state ack with a fixed, distinct response
+ * value), so a wrong routing/latching decision is unambiguous: RAM's
+ * fake value is 0xAAAA..., UART's is 0xBBBB..., and nothing else could
+ * produce either.
+ */
+module wb_addr_decoder_tb;
+
+    logic clk = 0;
+    always #5 clk = ~clk;
+    logic rst = 1;
+
+    logic [31:0] addr;
+    logic [63:0] dat_i, dat_o;
+    logic [7:0]  sel;
+    logic        ack, err, cyc, stb, we;
+
+    logic [31:0] ram_addr_o, uart_addr_o;
+    logic [63:0] ram_dat_o, uart_dat_o;
+    logic [7:0]  ram_sel_o, uart_sel_o;
+    logic        ram_we_o, ram_cyc_o, ram_stb_o, uart_we_o, uart_cyc_o, uart_stb_o;
+    logic [63:0] ram_dat_i, uart_dat_i;
+    logic        ram_ack_i, ram_err_i, uart_ack_i, uart_err_i;
+
+    wb_addr_decoder dut (
+        .clk(clk), .rst(rst),
+        .addr_i(addr), .dat_i(dat_i), .dat_o(dat_o), .sel_i(sel),
+        .we_i(we), .cyc_i(cyc), .stb_i(stb), .ack_o(ack), .err_o(err),
+        .ram_addr_o(ram_addr_o), .ram_dat_o(ram_dat_o), .ram_dat_i(ram_dat_i),
+        .ram_sel_o(ram_sel_o), .ram_we_o(ram_we_o), .ram_cyc_o(ram_cyc_o),
+        .ram_stb_o(ram_stb_o), .ram_ack_i(ram_ack_i), .ram_err_i(ram_err_i),
+        .uart_addr_o(uart_addr_o), .uart_dat_o(uart_dat_o), .uart_dat_i(uart_dat_i),
+        .uart_sel_o(uart_sel_o), .uart_we_o(uart_we_o), .uart_cyc_o(uart_cyc_o),
+        .uart_stb_o(uart_stb_o), .uart_ack_i(uart_ack_i), .uart_err_i(uart_err_i)
+    );
+
+    // Fake RAM: 1-wait-state ack, fixed distinguishable response.
+    always @(posedge clk) begin
+        if (rst) begin
+            ram_ack_i <= 0; ram_err_i <= 0; ram_dat_i <= 0;
+        end else if (ram_cyc_o && ram_stb_o) begin
+            ram_ack_i <= 1'b1; ram_dat_i <= 64'hAAAAAAAA_AAAAAAAA;
+        end else begin
+            ram_ack_i <= 1'b0;
+        end
+    end
+
+    // Fake UART: same shape, different fixed response.
+    always @(posedge clk) begin
+        if (rst) begin
+            uart_ack_i <= 0; uart_err_i <= 0; uart_dat_i <= 0;
+        end else if (uart_cyc_o && uart_stb_o) begin
+            uart_ack_i <= 1'b1; uart_dat_i <= 64'hBBBBBBBB_BBBBBBBB;
+        end else begin
+            uart_ack_i <= 1'b0;
+        end
+    end
+
+    int pass_count = 0;
+    int fail_count = 0;
+    task automatic check(string name, logic [63:0] actual, logic [63:0] expected);
+        if (actual === expected) begin
+            pass_count++;
+            $display("PASS: %s", name);
+        end else begin
+            fail_count++;
+            $display("FAIL: %s -- expected %h, got %h", name, expected, actual);
+        end
+    endtask
+
+    // Same #1-after-@(posedge clk) discipline established in
+    // wb4_sram_tb.sv/uart_tx_tb.sv -- see those files for why.
+    task automatic wb_cycle(logic [31:0] a);
+        @(negedge clk);
+        addr = a; dat_i = 0; sel = 8'hFF; we = 0; cyc = 1; stb = 1;
+        @(posedge clk); #1;
+        while (!ack) begin
+            @(posedge clk); #1;
+        end
+        cyc = 0; stb = 0;
+    endtask
+
+    initial begin
+        cyc = 0; stb = 0; we = 0; addr = 0; dat_i = 0; sel = 8'hFF;
+        @(posedge clk); #1;
+        rst = 0;
+
+        // RAM-range address: only ram_cyc_o should assert.
+        @(negedge clk);
+        addr = 32'h0000_0100; cyc = 1; stb = 1;
+        #1;
+        check("RAM address: ram_cyc_o asserted", {63'b0, ram_cyc_o}, 64'd1);
+        check("RAM address: uart_cyc_o stays low", {63'b0, uart_cyc_o}, 64'd0);
+        cyc = 0; stb = 0;
+        @(negedge clk);
+
+        // UART-range address: only uart_cyc_o should assert.
+        @(negedge clk);
+        addr = 32'h0000_8000; cyc = 1; stb = 1;
+        #1;
+        check("UART address: uart_cyc_o asserted", {63'b0, uart_cyc_o}, 64'd1);
+        check("UART address: ram_cyc_o stays low", {63'b0, ram_cyc_o}, 64'd0);
+        cyc = 0; stb = 0;
+        @(negedge clk);
+
+        // Full round trip, RAM then UART back-to-back -- exercises
+        // sel_uart_q actually updating between two different-slave
+        // transactions, not just holding whatever it started as.
+        wb_cycle(32'h0000_0200);
+        check("response routed from RAM", dat_o, 64'hAAAAAAAA_AAAAAAAA);
+
+        wb_cycle(32'h0000_8008);
+        check("response routed from UART (latch updated, not stuck on RAM)", dat_o, 64'hBBBBBBBB_BBBBBBBB);
+
+        wb_cycle(32'h0000_0300);
+        check("response routed back to RAM (latch updates both directions)", dat_o, 64'hAAAAAAAA_AAAAAAAA);
+
+        $display("");
+        $display("wb_addr_decoder_tb: %0d passed, %0d failed", pass_count, fail_count);
+        if (fail_count > 0) $display("wb_addr_decoder_tb: FAILURES PRESENT");
+        $finish;
+    end
+
+endmodule

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -4,4 +4,12 @@ all:
 	riscv64-unknown-elf-as -march=rv64i -mabi=lp64 crt0.s -o crt0.o
 	riscv64-unknown-elf-ld -Ttext=0x0 -o crt0.elf crt0.o
 	riscv64-unknown-elf-objdump -d crt0.elf
-	riscv64-unknown-elf-objcopy -O verilog --verilog-data-width=4 crt0.elf crt0.hex
+	# --verilog-data-width=8: one 64-bit $readmemh element per line, matching
+	#   wb4_sram.sv's memory[] (widened to 64 bits -- see that file's own header).
+	# --reverse-bytes=8: objcopy's verilog writer packs address-ascending bytes
+	#   as the MOST-significant part of each hex token; $readmemh loading that
+	#   into memory[i][63:0] would then put byte@lowest_address at [63:56], the
+	#   opposite of the little-endian convention memory[i][7:0]==byte@lowest_address
+	#   this design uses everywhere else (dmem.sv, wb4_sram.sv's own write path).
+	#   This flag corrects the byte order at export time instead.
+	riscv64-unknown-elf-objcopy -O verilog --verilog-data-width=8 --reverse-bytes=8 crt0.elf crt0.hex

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -4,12 +4,17 @@ all:
 	riscv64-unknown-elf-as -march=rv64i -mabi=lp64 crt0.s -o crt0.o
 	riscv64-unknown-elf-ld -Ttext=0x0 -o crt0.elf crt0.o
 	riscv64-unknown-elf-objdump -d crt0.elf
-	# --verilog-data-width=8: one 64-bit $readmemh element per line, matching
+	# -j .text: only convert .text -- .riscv.attributes (toolchain metadata
+	#   the linker adds, not something we want loaded into memory at all)
+	#   isn't a multiple of 8 bytes long, which --reverse-bytes=8 would
+	#   choke on if it were applied to the whole file instead.
+	# --verilog-data-width=8: one 64-bit $$readmemh element per line, matching
 	#   wb4_sram.sv's memory[] (widened to 64 bits -- see that file's own header).
-	# --reverse-bytes=8: objcopy's verilog writer packs address-ascending bytes
-	#   as the MOST-significant part of each hex token; $readmemh loading that
-	#   into memory[i][63:0] would then put byte@lowest_address at [63:56], the
-	#   opposite of the little-endian convention memory[i][7:0]==byte@lowest_address
-	#   this design uses everywhere else (dmem.sv, wb4_sram.sv's own write path).
-	#   This flag corrects the byte order at export time instead.
-	riscv64-unknown-elf-objcopy -O verilog --verilog-data-width=8 --reverse-bytes=8 crt0.elf crt0.hex
+	# NO --reverse-bytes: verified by hand against a real build (objdump -d
+	#   plus the raw hex output) that objcopy's verilog writer already emits
+	#   bytes in the order $$readmemh needs for this design's convention --
+	#   memory[i][7:0] == byte@lowest_address -- with no extra flag. Adding
+	#   --reverse-bytes=8, which an earlier untested assumption here called
+	#   for, actually produces the WRONG order; don't re-add it without
+	#   re-deriving this by hand against real objdump output first.
+	riscv64-unknown-elf-objcopy -O verilog -j .text --verilog-data-width=8 crt0.elf crt0.hex

--- a/firmware/Makefile
+++ b/firmware/Makefile
@@ -1,13 +1,21 @@
 
 
+# -mno-relax on both the assembler and gcc: disables linker relaxation
+#   of small-data accesses into gp-relative instructions, so crt0.s
+#   doesn't need to set up gp at all -- see that file's own header.
+ASFLAGS = -march=rv64i -mabi=lp64 -mno-relax
+CFLAGS  = -march=rv64i -mabi=lp64 -mno-relax -ffreestanding -nostdlib -O0 -Wall
+
 all:
-	riscv64-unknown-elf-as -march=rv64i -mabi=lp64 crt0.s -o crt0.o
-	riscv64-unknown-elf-ld -Ttext=0x0 -o crt0.elf crt0.o
+	riscv64-unknown-elf-as $(ASFLAGS) crt0.s -o crt0.o
+	riscv64-unknown-elf-gcc $(CFLAGS) -c hello.c -o hello.o
+	riscv64-unknown-elf-ld -T link.ld -o crt0.elf crt0.o hello.o
 	riscv64-unknown-elf-objdump -d crt0.elf
-	# -j .text: only convert .text -- .riscv.attributes (toolchain metadata
-	#   the linker adds, not something we want loaded into memory at all)
-	#   isn't a multiple of 8 bytes long, which --reverse-bytes=8 would
-	#   choke on if it were applied to the whole file instead.
+	# -j .text -j .rodata -j .data: only convert sections holding real
+	#   runtime content -- excludes .riscv.attributes (toolchain metadata,
+	#   not something we want loaded into memory) and .bss (zero-
+	#   initialized, holds no file content to begin with; crt0.s zeros it
+	#   at runtime instead -- see link.ld's comment on that section).
 	# --verilog-data-width=8: one 64-bit $$readmemh element per line, matching
 	#   wb4_sram.sv's memory[] (widened to 64 bits -- see that file's own header).
 	# NO --reverse-bytes: verified by hand against a real build (objdump -d
@@ -17,4 +25,4 @@ all:
 	#   --reverse-bytes=8, which an earlier untested assumption here called
 	#   for, actually produces the WRONG order; don't re-add it without
 	#   re-deriving this by hand against real objdump output first.
-	riscv64-unknown-elf-objcopy -O verilog -j .text --verilog-data-width=8 crt0.elf crt0.hex
+	riscv64-unknown-elf-objcopy -O verilog -j .text -j .rodata -j .data --verilog-data-width=8 crt0.elf crt0.hex

--- a/firmware/crt0.s
+++ b/firmware/crt0.s
@@ -1,48 +1,42 @@
     .section .text
     .globl _start
 
-# Hello-world for the minimal SoC (design/soc.sv): print "Hello, World!\n"
-# one byte at a time through the UART's memory-mapped TX_DATA register
-# (design/uart_tx.sv, address 0x8000). x1 holds that address for the
-# whole program; x2 is reused as the one-byte payload for each write.
+# Startup stub for the minimal SoC (design/soc.sv) -- sets up the two
+# things any nontrivial C function needs before it's safe to call into
+# C at all, then hands off to main() (firmware/hello.c). Previously this
+# file WAS the whole program, hand-written to avoid depending on
+# unverified section-placement behavior; now that firmware/link.ld
+# exists and has been verified against a real build, the actual program
+# logic lives in C instead. See git history for the assembly-only version.
 #
-# Deliberately a flat, repeated li+sb sequence rather than a string
-# constant walked in a loop -- this milestone links with a bare
-# `-Ttext=0x0` and no linker script, so there's no established, verified
-# convention yet for where a .data/.rodata section would actually land.
-# A loop over a real string is the natural next step once that exists;
-# until then, this avoids depending on section-placement behavior that
-# hasn't been proven on this toolchain/link setup.
+#  - sp (x2): without this, the first push (e.g. a saved return address,
+#    or any register a called function spills) writes to address 0 --
+#    which happens to be this program's own first instruction. Set to
+#    _stack_top (firmware/link.ld), the top of RAM, growing down.
+#  - .bss zeroed: C assumes zero-initialized globals/statics.
+#
+# gp (x3, RISC-V's "global pointer") is deliberately NOT set up --
+# firmware/Makefile passes -mno-relax to both the assembler and gcc,
+# which disables the linker relaxation that would otherwise rewrite
+# small-data accesses into gp-relative instructions. Without that
+# relaxation, gp-relative addressing never gets emitted, so gp can stay
+# uninitialized without breaking anything.
 _start:
-    li x1, 0x8000
+    la sp, _stack_top
 
-    li x2, 'H'
-    sb x2, 0(x1)
-    li x2, 'e'
-    sb x2, 0(x1)
-    li x2, 'l'
-    sb x2, 0(x1)
-    li x2, 'l'
-    sb x2, 0(x1)
-    li x2, 'o'
-    sb x2, 0(x1)
-    li x2, ','
-    sb x2, 0(x1)
-    li x2, ' '
-    sb x2, 0(x1)
-    li x2, 'W'
-    sb x2, 0(x1)
-    li x2, 'o'
-    sb x2, 0(x1)
-    li x2, 'r'
-    sb x2, 0(x1)
-    li x2, 'l'
-    sb x2, 0(x1)
-    li x2, 'd'
-    sb x2, 0(x1)
-    li x2, '!'
-    sb x2, 0(x1)
-    li x2, '\n'
-    sb x2, 0(x1)
+    la t0, _bss_start
+    la t1, _bss_end
+zero_bss:
+    bge t0, t1, zero_bss_done
+    sb x0, 0(t0)
+    addi t0, t0, 1
+    j zero_bss
+zero_bss_done:
 
+    call main
+
+    # main() has no OS to return to -- halt the same way every other
+    # firmware image in this repo signals "done" (see core.sv's halt
+    # latch). main()'s return value (a0) is deliberately not inspected;
+    # there's nothing to report it to yet.
     ebreak

--- a/firmware/crt0.s
+++ b/firmware/crt0.s
@@ -1,13 +1,48 @@
     .section .text
     .globl _start
 
+# Hello-world for the minimal SoC (design/soc.sv): print "Hello, World!\n"
+# one byte at a time through the UART's memory-mapped TX_DATA register
+# (design/uart_tx.sv, address 0x8000). x1 holds that address for the
+# whole program; x2 is reused as the one-byte payload for each write.
+#
+# Deliberately a flat, repeated li+sb sequence rather than a string
+# constant walked in a loop -- this milestone links with a bare
+# `-Ttext=0x0` and no linker script, so there's no established, verified
+# convention yet for where a .data/.rodata section would actually land.
+# A loop over a real string is the natural next step once that exists;
+# until then, this avoids depending on section-placement behavior that
+# hasn't been proven on this toolchain/link setup.
 _start:
-    addi x1, x0, 5      # x1 = 5
-    addi x2, x0, 3      # x2 = 3
-    add  x3, x1, x2     # x3 = 8
-    sd   x3, 0(x0)      # mem[0] = 8
-    li   x4, 4          # x4 = 4
-loop:
-    addi x4, x4, -1     # x4--
-    bnez x4, loop       # branch until x4 == 0
-    ebreak              # done
+    li x1, 0x8000
+
+    li x2, 'H'
+    sb x2, 0(x1)
+    li x2, 'e'
+    sb x2, 0(x1)
+    li x2, 'l'
+    sb x2, 0(x1)
+    li x2, 'l'
+    sb x2, 0(x1)
+    li x2, 'o'
+    sb x2, 0(x1)
+    li x2, ','
+    sb x2, 0(x1)
+    li x2, ' '
+    sb x2, 0(x1)
+    li x2, 'W'
+    sb x2, 0(x1)
+    li x2, 'o'
+    sb x2, 0(x1)
+    li x2, 'r'
+    sb x2, 0(x1)
+    li x2, 'l'
+    sb x2, 0(x1)
+    li x2, 'd'
+    sb x2, 0(x1)
+    li x2, '!'
+    sb x2, 0(x1)
+    li x2, '\n'
+    sb x2, 0(x1)
+
+    ebreak

--- a/firmware/hello.c
+++ b/firmware/hello.c
@@ -1,0 +1,23 @@
+/*
+ * Hello-world for the minimal SoC (design/soc.sv) -- the actual program
+ * logic; firmware/crt0.s only sets up sp/.bss and calls main().
+ *
+ * Freestanding: no libc (-nostdlib in firmware/Makefile), so this can't
+ * use printf or even strlen. The UART's TX_DATA register is written
+ * directly through a volatile pointer -- volatile is load-bearing here,
+ * not decoration: without it, the compiler is free to treat repeated
+ * writes to the same address with no intervening read as dead stores
+ * and drop all but the last one, since nothing about a plain write
+ * tells it this address has an observable side effect.
+ */
+
+#define UART_TX_DATA ((volatile unsigned char *)0x8000)
+
+static const char msg[] = "Hello, World!\n";
+
+int main(void) {
+    for (int i = 0; msg[i] != '\0'; i++) {
+        *UART_TX_DATA = (unsigned char)msg[i];
+    }
+    return 0;
+}

--- a/firmware/link.ld
+++ b/firmware/link.ld
@@ -1,0 +1,55 @@
+/*
+ * Linker script for the minimal SoC (design/soc.sv).
+ *
+ * RAM spans 0x0000-0x7FFF -- wb4_sram.sv's default 4096 x 8-byte words
+ * = 32KB, and the exact boundary design/wb_addr_decoder.sv routes on
+ * (addr bit 15): anything at or past 0x8000 lands on the UART instead
+ * of memory, not an error, just silently the wrong device. .text is
+ * placed first so it starts at 0x0, matching core.sv's reset vector
+ * (pc resets to 0) -- crt0.o must be the first object passed to `ld`
+ * for its _start to actually land there; this script alone doesn't
+ * guarantee input-file order.
+ *
+ * The stack starts at the very top of RAM and grows down. For this
+ * milestone's tiny C programs it will never collide with
+ * .text/.rodata/.data/.bss, but nothing here enforces that -- a much
+ * bigger program could grow .bss up into the stack with no warning.
+ */
+ENTRY(_start)
+
+MEMORY
+{
+    RAM (rwx) : ORIGIN = 0x00000000, LENGTH = 0x8000
+}
+
+SECTIONS
+{
+    .text : {
+        *(.text*)
+    } > RAM
+
+    .rodata : {
+        *(.rodata*)
+    } > RAM
+
+    .data : {
+        *(.data*)
+    } > RAM
+
+    /*
+     * _bss_start/_bss_end are consumed by crt0.s's zero-fill loop. Real
+     * hardware gives .bss no zero-initialization guarantee at all;
+     * design/wb4_sram.sv happens to zero-fill everything in simulation
+     * (see that file's own header), which would silently paper over a
+     * missing zero-loop here -- crt0.s zeros it explicitly anyway,
+     * since that simulator behavior isn't something to rely on.
+     */
+    .bss : {
+        _bss_start = .;
+        *(.bss*)
+        *(COMMON)
+        _bss_end = .;
+    } > RAM
+
+    _stack_top = ORIGIN(RAM) + LENGTH(RAM);
+}

--- a/testbench/core_alu_ops_tb.sv
+++ b/testbench/core_alu_ops_tb.sv
@@ -14,12 +14,14 @@
  * Testbench: core, register-immediate / register-register ALU ops
  *
  * First integration test -- exercises the plain fetch -> decode -> ALU ->
- * writeback path only, no memory or branch/jump complexity yet (those
- * are added one at a time by the testbenches after this one).
+ * writeback path only, no branch/jump complexity yet (those are added
+ * one at a time by the testbenches after this one).
  *
  * Instructions are hand-encoded via riscv_encode.sv and poked directly
- * into imem0 -- no riscv64-unknown-elf toolchain dependency for this
- * stage.
+ * into a real wb4_sram instance's memory[] array, packed two 32-bit
+ * instructions per 64-bit word (core.sv fetches over the Wishbone bus
+ * now, not from a private imem0) -- no riscv64-unknown-elf toolchain
+ * dependency for this stage.
  */
 module core_alu_ops_tb;
 
@@ -28,7 +30,25 @@ module core_alu_ops_tb;
 
     logic rst = 1;
 
-    core dut (.clk(clk), .rst(rst));
+    logic [31:0] wb_addr;
+    logic [63:0] wb_dat_m2s, wb_dat_s2m;
+    logic [7:0]  wb_sel;
+    logic        wb_we, wb_cyc, wb_stb, wb_ack, wb_err;
+
+    core dut (
+        .clk(clk), .rst(rst),
+        .wb_addr_o(wb_addr), .wb_dat_o(wb_dat_m2s), .wb_dat_i(wb_dat_s2m),
+        .wb_sel_o(wb_sel), .wb_we_o(wb_we), .wb_cyc_o(wb_cyc), .wb_stb_o(wb_stb),
+        .wb_ack_i(wb_ack), .wb_err_i(wb_err)
+    );
+
+    /* No UART/decoder needed -- this test never touches a memory-mapped
+     * peripheral, so core is wired straight to a single wb4_sram. */
+    wb4_sram #(.num_words(128)) sram0 (
+        .clk(clk), .rst(rst),
+        .addr_i(wb_addr), .dat_i(wb_dat_m2s), .dat_o(wb_dat_s2m), .sel_i(wb_sel),
+        .ack_o(wb_ack), .err_o(wb_err), .cyc_i(wb_cyc), .stb_i(wb_stb), .we_i(wb_we)
+    );
 
     int pass_count = 0;
     int fail_count = 0;
@@ -43,6 +63,8 @@ module core_alu_ops_tb;
     endtask
 
     initial begin
+        #1; // run after wb4_sram's own time-0 init (zero-fill + $readmemh) -- see core_wb_tb.sv
+
         /*
          * addi x1, x0, 5        x1 = 5
          * addi x2, x0, -3       x2 = -3  (negative I-immediate sign-extension)
@@ -55,14 +77,14 @@ module core_alu_ops_tb;
          *                                              SRA fix to land on the right answer)
          * ebreak
          */
-        dut.imem0.mem[0] = encode_i(32'sd5, 5'd0, 3'b000, 5'd1, `OPC_OP_IMM);
-        dut.imem0.mem[1] = encode_i(-32'sd3, 5'd0, 3'b000, 5'd2, `OPC_OP_IMM);
-        dut.imem0.mem[2] = encode_r(7'b0000000, 5'd2, 5'd1, 3'b000, 5'd3, `OPC_OP);
-        dut.imem0.mem[3] = encode_r(7'b0100000, 5'd2, 5'd1, 3'b000, 5'd4, `OPC_OP);
-        dut.imem0.mem[4] = encode_i(32'sd0, 5'd2, 3'b010, 5'd5, `OPC_OP_IMM);
-        dut.imem0.mem[5] = encode_shift64(6'b000000, 6'd2, 5'd1, 3'b001, 5'd6, `OPC_OP_IMM);
-        dut.imem0.mem[6] = encode_shift64(6'b010000, 6'd1, 5'd2, 3'b101, 5'd7, `OPC_OP_IMM);
-        dut.imem0.mem[7] = {11'b0, 1'b1, 13'b0, `OPC_SYSTEM}; // ebreak
+        sram0.memory[0] = {encode_i(-32'sd3, 5'd0, 3'b000, 5'd2, `OPC_OP_IMM),
+                            encode_i(32'sd5, 5'd0, 3'b000, 5'd1, `OPC_OP_IMM)};
+        sram0.memory[1] = {encode_r(7'b0100000, 5'd2, 5'd1, 3'b000, 5'd4, `OPC_OP),
+                            encode_r(7'b0000000, 5'd2, 5'd1, 3'b000, 5'd3, `OPC_OP)};
+        sram0.memory[2] = {encode_shift64(6'b000000, 6'd2, 5'd1, 3'b001, 5'd6, `OPC_OP_IMM),
+                            encode_i(32'sd0, 5'd2, 3'b010, 5'd5, `OPC_OP_IMM)};
+        sram0.memory[3] = {{11'b0, 1'b1, 13'b0, `OPC_SYSTEM}, // ebreak
+                            encode_shift64(6'b010000, 6'd1, 5'd2, 3'b101, 5'd7, `OPC_OP_IMM)};
 
         @(posedge clk); #1;
         rst = 0;
@@ -70,7 +92,7 @@ module core_alu_ops_tb;
         fork
             wait (dut.halted === 1'b1);
             begin
-                repeat (50) @(posedge clk);
+                repeat (150) @(posedge clk);
                 $display("TIMEOUT: dut.halted never went high");
                 $finish;
             end

--- a/testbench/core_branch_jump_tb.sv
+++ b/testbench/core_branch_jump_tb.sv
@@ -31,7 +31,23 @@ module core_branch_jump_tb;
 
     logic rst = 1;
 
-    core dut (.clk(clk), .rst(rst));
+    logic [31:0] wb_addr;
+    logic [63:0] wb_dat_m2s, wb_dat_s2m;
+    logic [7:0]  wb_sel;
+    logic        wb_we, wb_cyc, wb_stb, wb_ack, wb_err;
+
+    core dut (
+        .clk(clk), .rst(rst),
+        .wb_addr_o(wb_addr), .wb_dat_o(wb_dat_m2s), .wb_dat_i(wb_dat_s2m),
+        .wb_sel_o(wb_sel), .wb_we_o(wb_we), .wb_cyc_o(wb_cyc), .wb_stb_o(wb_stb),
+        .wb_ack_i(wb_ack), .wb_err_i(wb_err)
+    );
+
+    wb4_sram #(.num_words(128)) sram0 (
+        .clk(clk), .rst(rst),
+        .addr_i(wb_addr), .dat_i(wb_dat_m2s), .dat_o(wb_dat_s2m), .sel_i(wb_sel),
+        .ack_o(wb_ack), .err_o(wb_err), .cyc_i(wb_cyc), .stb_i(wb_stb), .we_i(wb_we)
+    );
 
     int pass_count = 0;
     int fail_count = 0;
@@ -46,6 +62,8 @@ module core_branch_jump_tb;
     endtask
 
     initial begin
+        #1; // run after wb4_sram's own time-0 init (zero-fill + $readmemh) -- see core_wb_tb.sv
+
         /*
          * addr  idx  instruction                    notes
          *  0     0   addi x1,x0,1
@@ -72,29 +90,30 @@ module core_branch_jump_tb;
          * 84    21   addi x12,x0,222                 jalr lands here
          * 88    22   ebreak
          */
-        dut.imem0.mem[0]  = encode_i(32'sd1, 5'd0, 3'b000, 5'd1, `OPC_OP_IMM);
-        dut.imem0.mem[1]  = encode_i(32'sd1, 5'd0, 3'b000, 5'd2, `OPC_OP_IMM);
-        dut.imem0.mem[2]  = encode_b(32'sd12, 5'd2, 5'd1, 3'b000, `OPC_BRANCH); // beq
-        dut.imem0.mem[3]  = encode_i(32'sd111, 5'd0, 3'b000, 5'd3, `OPC_OP_IMM);
-        dut.imem0.mem[4]  = encode_j(32'sd8, 5'd0, `OPC_JAL);
-        dut.imem0.mem[5]  = encode_i(32'sd222, 5'd0, 3'b000, 5'd3, `OPC_OP_IMM);
-        dut.imem0.mem[6]  = encode_i(-32'sd1, 5'd0, 3'b000, 5'd4, `OPC_OP_IMM);
-        dut.imem0.mem[7]  = encode_i(32'sd1, 5'd0, 3'b000, 5'd5, `OPC_OP_IMM);
-        dut.imem0.mem[8]  = encode_b(32'sd12, 5'd5, 5'd4, 3'b100, `OPC_BRANCH); // blt
-        dut.imem0.mem[9]  = encode_i(32'sd111, 5'd0, 3'b000, 5'd6, `OPC_OP_IMM);
-        dut.imem0.mem[10] = encode_j(32'sd8, 5'd0, `OPC_JAL);
-        dut.imem0.mem[11] = encode_i(32'sd222, 5'd0, 3'b000, 5'd6, `OPC_OP_IMM);
-        dut.imem0.mem[12] = encode_b(32'sd12, 5'd5, 5'd4, 3'b110, `OPC_BRANCH); // bltu
-        dut.imem0.mem[13] = encode_i(32'sd222, 5'd0, 3'b000, 5'd7, `OPC_OP_IMM);
-        dut.imem0.mem[14] = encode_j(32'sd8, 5'd0, `OPC_JAL);
-        dut.imem0.mem[15] = encode_i(32'sd111, 5'd0, 3'b000, 5'd7, `OPC_OP_IMM);
-        dut.imem0.mem[16] = encode_j(32'sd8, 5'd8, `OPC_JAL);
-        dut.imem0.mem[17] = encode_i(32'sd111, 5'd0, 3'b000, 5'd9, `OPC_OP_IMM);
-        dut.imem0.mem[18] = encode_i(32'sd78, 5'd0, 3'b000, 5'd11, `OPC_OP_IMM);
-        dut.imem0.mem[19] = encode_i(32'sd7, 5'd11, 3'b000, 5'd10, `OPC_JALR);
-        dut.imem0.mem[20] = encode_i(32'sd111, 5'd0, 3'b000, 5'd12, `OPC_OP_IMM);
-        dut.imem0.mem[21] = encode_i(32'sd222, 5'd0, 3'b000, 5'd12, `OPC_OP_IMM);
-        dut.imem0.mem[22] = {11'b0, 1'b1, 13'b0, `OPC_SYSTEM}; // ebreak
+        sram0.memory[0]  = {encode_i(32'sd1, 5'd0, 3'b000, 5'd2, `OPC_OP_IMM),
+                             encode_i(32'sd1, 5'd0, 3'b000, 5'd1, `OPC_OP_IMM)};
+        sram0.memory[1]  = {encode_i(32'sd111, 5'd0, 3'b000, 5'd3, `OPC_OP_IMM),
+                             encode_b(32'sd12, 5'd2, 5'd1, 3'b000, `OPC_BRANCH)}; // beq
+        sram0.memory[2]  = {encode_i(32'sd222, 5'd0, 3'b000, 5'd3, `OPC_OP_IMM),
+                             encode_j(32'sd8, 5'd0, `OPC_JAL)};
+        sram0.memory[3]  = {encode_i(32'sd1, 5'd0, 3'b000, 5'd5, `OPC_OP_IMM),
+                             encode_i(-32'sd1, 5'd0, 3'b000, 5'd4, `OPC_OP_IMM)};
+        sram0.memory[4]  = {encode_i(32'sd111, 5'd0, 3'b000, 5'd6, `OPC_OP_IMM),
+                             encode_b(32'sd12, 5'd5, 5'd4, 3'b100, `OPC_BRANCH)}; // blt
+        sram0.memory[5]  = {encode_i(32'sd222, 5'd0, 3'b000, 5'd6, `OPC_OP_IMM),
+                             encode_j(32'sd8, 5'd0, `OPC_JAL)};
+        sram0.memory[6]  = {encode_i(32'sd222, 5'd0, 3'b000, 5'd7, `OPC_OP_IMM),
+                             encode_b(32'sd12, 5'd5, 5'd4, 3'b110, `OPC_BRANCH)}; // bltu
+        sram0.memory[7]  = {encode_i(32'sd111, 5'd0, 3'b000, 5'd7, `OPC_OP_IMM),
+                             encode_j(32'sd8, 5'd0, `OPC_JAL)};
+        sram0.memory[8]  = {encode_i(32'sd111, 5'd0, 3'b000, 5'd9, `OPC_OP_IMM),
+                             encode_j(32'sd8, 5'd8, `OPC_JAL)};
+        sram0.memory[9]  = {encode_i(32'sd7, 5'd11, 3'b000, 5'd10, `OPC_JALR),
+                             encode_i(32'sd78, 5'd0, 3'b000, 5'd11, `OPC_OP_IMM)};
+        sram0.memory[10] = {encode_i(32'sd222, 5'd0, 3'b000, 5'd12, `OPC_OP_IMM),
+                             encode_i(32'sd111, 5'd0, 3'b000, 5'd12, `OPC_OP_IMM)};
+        sram0.memory[11] = {32'b0, // unreachable padding -- halted after idx22, never fetched
+                             {11'b0, 1'b1, 13'b0, `OPC_SYSTEM}}; // ebreak
 
         @(posedge clk); #1;
         rst = 0;
@@ -102,7 +121,7 @@ module core_branch_jump_tb;
         fork
             wait (dut.halted === 1'b1);
             begin
-                repeat (60) @(posedge clk);
+                repeat (150) @(posedge clk);
                 $display("TIMEOUT: dut.halted never went high");
                 $finish;
             end

--- a/testbench/core_load_store_tb.sv
+++ b/testbench/core_load_store_tb.sv
@@ -13,8 +13,9 @@
 /*
  * Testbench: core, loads and stores
  *
- * Adds the memory subsystem (dmem, byte-enable writes) on top of
- * core_alu_ops_tb's plain path.
+ * Adds the memory subsystem on top of core_alu_ops_tb's plain path --
+ * loads/stores now go out over the real Wishbone bus to a real wb4_sram
+ * instance (core.sv has no private dmem anymore; see its own header).
  *
  * The negative-offset SW case is the important one: SW's address comes
  * from imm_s (S-type), which had the 12-vs-13-bit zero-pad bug -- LW's
@@ -31,7 +32,25 @@ module core_load_store_tb;
 
     logic rst = 1;
 
-    core dut (.clk(clk), .rst(rst));
+    logic [31:0] wb_addr;
+    logic [63:0] wb_dat_m2s, wb_dat_s2m;
+    logic [7:0]  wb_sel;
+    logic        wb_we, wb_cyc, wb_stb, wb_ack, wb_err;
+
+    core dut (
+        .clk(clk), .rst(rst),
+        .wb_addr_o(wb_addr), .wb_dat_o(wb_dat_m2s), .wb_dat_i(wb_dat_s2m),
+        .wb_sel_o(wb_sel), .wb_we_o(wb_we), .wb_cyc_o(wb_cyc), .wb_stb_o(wb_stb),
+        .wb_ack_i(wb_ack), .wb_err_i(wb_err)
+    );
+
+    /* num_words(128) covers the highest address this test touches (0x1FC,
+     * word index 63) with headroom -- see core_wb_tb.sv for the same sizing. */
+    wb4_sram #(.num_words(128)) sram0 (
+        .clk(clk), .rst(rst),
+        .addr_i(wb_addr), .dat_i(wb_dat_m2s), .dat_o(wb_dat_s2m), .sel_i(wb_sel),
+        .ack_o(wb_ack), .err_o(wb_err), .cyc_i(wb_cyc), .stb_i(wb_stb), .we_i(wb_we)
+    );
 
     int pass_count = 0;
     int fail_count = 0;
@@ -46,6 +65,8 @@ module core_load_store_tb;
     endtask
 
     initial begin
+        #1; // run after wb4_sram's own time-0 init (zero-fill + $readmemh) -- see core_wb_tb.sv
+
         /*
          * addi x1, x0, 0x100    base address for the byte test
          * addi x2, x0, -1       x2 = 0xFFFF...FFFF (low byte = 0xFF)
@@ -62,18 +83,18 @@ module core_load_store_tb;
          *                        used here as the check)
          * ebreak
          */
-        dut.imem0.mem[0]  = encode_i(32'sh100, 5'd0, 3'b000, 5'd1, `OPC_OP_IMM);
-        dut.imem0.mem[1]  = encode_i(-32'sd1, 5'd0, 3'b000, 5'd2, `OPC_OP_IMM);
-        dut.imem0.mem[2]  = encode_s(32'sd0, 5'd2, 5'd1, 3'b000, `OPC_STORE);
-        dut.imem0.mem[3]  = encode_i(32'sd0, 5'd1, 3'b000, 5'd3, `OPC_LOAD);
-        dut.imem0.mem[4]  = encode_i(32'sd0, 5'd1, 3'b100, 5'd4, `OPC_LOAD);
-        dut.imem0.mem[5]  = encode_s(32'sd8, 5'd2, 5'd1, 3'b011, `OPC_STORE);
-        dut.imem0.mem[6]  = encode_i(32'sd8, 5'd1, 3'b011, 5'd5, `OPC_LOAD);
-        dut.imem0.mem[7]  = encode_i(32'sh200, 5'd0, 3'b000, 5'd7, `OPC_OP_IMM);
-        dut.imem0.mem[8]  = encode_i(32'sh555, 5'd0, 3'b000, 5'd8, `OPC_OP_IMM);
-        dut.imem0.mem[9]  = encode_s(-32'sd4, 5'd8, 5'd7, 3'b010, `OPC_STORE);
-        dut.imem0.mem[10] = encode_i(-32'sd4, 5'd7, 3'b010, 5'd9, `OPC_LOAD);
-        dut.imem0.mem[11] = {11'b0, 1'b1, 13'b0, `OPC_SYSTEM}; // ebreak
+        sram0.memory[0] = {encode_i(-32'sd1, 5'd0, 3'b000, 5'd2, `OPC_OP_IMM),
+                            encode_i(32'sh100, 5'd0, 3'b000, 5'd1, `OPC_OP_IMM)};
+        sram0.memory[1] = {encode_i(32'sd0, 5'd1, 3'b000, 5'd3, `OPC_LOAD),
+                            encode_s(32'sd0, 5'd2, 5'd1, 3'b000, `OPC_STORE)};
+        sram0.memory[2] = {encode_s(32'sd8, 5'd2, 5'd1, 3'b011, `OPC_STORE),
+                            encode_i(32'sd0, 5'd1, 3'b100, 5'd4, `OPC_LOAD)};
+        sram0.memory[3] = {encode_i(32'sh200, 5'd0, 3'b000, 5'd7, `OPC_OP_IMM),
+                            encode_i(32'sd8, 5'd1, 3'b011, 5'd5, `OPC_LOAD)};
+        sram0.memory[4] = {encode_s(-32'sd4, 5'd8, 5'd7, 3'b010, `OPC_STORE),
+                            encode_i(32'sh555, 5'd0, 3'b000, 5'd8, `OPC_OP_IMM)};
+        sram0.memory[5] = {{11'b0, 1'b1, 13'b0, `OPC_SYSTEM}, // ebreak
+                            encode_i(-32'sd4, 5'd7, 3'b010, 5'd9, `OPC_LOAD)};
 
         @(posedge clk); #1;
         rst = 0;
@@ -81,7 +102,7 @@ module core_load_store_tb;
         fork
             wait (dut.halted === 1'b1);
             begin
-                repeat (50) @(posedge clk);
+                repeat (150) @(posedge clk);
                 $display("TIMEOUT: dut.halted never went high");
                 $finish;
             end

--- a/testbench/core_rv64_word_ops_tb.sv
+++ b/testbench/core_rv64_word_ops_tb.sv
@@ -33,7 +33,23 @@ module core_rv64_word_ops_tb;
 
     logic rst = 1;
 
-    core dut (.clk(clk), .rst(rst));
+    logic [31:0] wb_addr;
+    logic [63:0] wb_dat_m2s, wb_dat_s2m;
+    logic [7:0]  wb_sel;
+    logic        wb_we, wb_cyc, wb_stb, wb_ack, wb_err;
+
+    core dut (
+        .clk(clk), .rst(rst),
+        .wb_addr_o(wb_addr), .wb_dat_o(wb_dat_m2s), .wb_dat_i(wb_dat_s2m),
+        .wb_sel_o(wb_sel), .wb_we_o(wb_we), .wb_cyc_o(wb_cyc), .wb_stb_o(wb_stb),
+        .wb_ack_i(wb_ack), .wb_err_i(wb_err)
+    );
+
+    wb4_sram #(.num_words(128)) sram0 (
+        .clk(clk), .rst(rst),
+        .addr_i(wb_addr), .dat_i(wb_dat_m2s), .dat_o(wb_dat_s2m), .sel_i(wb_sel),
+        .ack_o(wb_ack), .err_o(wb_err), .cyc_i(wb_cyc), .stb_i(wb_stb), .we_i(wb_we)
+    );
 
     int pass_count = 0;
     int fail_count = 0;
@@ -48,6 +64,8 @@ module core_rv64_word_ops_tb;
     endtask
 
     initial begin
+        #1; // run after wb4_sram's own time-0 init (zero-fill + $readmemh) -- see core_wb_tb.sv
+
         /*
          * addi x1,x0,-1     x1 = 0xFFFFFFFFFFFFFFFF
          * slli x1,x1,32     x1 = 0xFFFFFFFF00000000
@@ -69,16 +87,16 @@ module core_rv64_word_ops_tb;
          *                         0x0000000100000000 -- completely different, easy to catch)
          * ebreak
          */
-        dut.imem0.mem[0] = encode_i(-32'sd1, 5'd0, 3'b000, 5'd1, `OPC_OP_IMM);
-        dut.imem0.mem[1] = encode_shift64(6'b000000, 6'd32, 5'd1, 3'b001, 5'd1, `OPC_OP_IMM); // slli
-        dut.imem0.mem[2] = encode_shift64(6'b000000, 6'd32, 5'd1, 3'b101, 5'd1, `OPC_OP_IMM); // srli
-        dut.imem0.mem[3] = encode_r(7'b0000000, 5'd0, 5'd1, 3'b000, 5'd2, `OPC_OP_32);        // addw
-        dut.imem0.mem[4] = encode_r(7'b0000000, 5'd0, 5'd1, 3'b000, 5'd3, `OPC_OP);           // add
-        dut.imem0.mem[5] = encode_i(32'sd4, 5'd0, 3'b000, 5'd5, `OPC_OP_IMM);                 // addi x5,x0,4
-        dut.imem0.mem[6] = encode_r(7'b0100000, 5'd5, 5'd1, 3'b101, 5'd6, `OPC_OP_32);        // sraw
-        dut.imem0.mem[7] = encode_r(7'b0000000, 5'd5, 5'd1, 3'b101, 5'd7, `OPC_OP_32);        // srlw
-        dut.imem0.mem[8] = encode_i(32'sd1, 5'd1, 3'b000, 5'd9, `OPC_OP_IMM_32);              // addiw
-        dut.imem0.mem[9] = {11'b0, 1'b1, 13'b0, `OPC_SYSTEM};                                  // ebreak
+        sram0.memory[0] = {encode_shift64(6'b000000, 6'd32, 5'd1, 3'b001, 5'd1, `OPC_OP_IMM), // slli
+                            encode_i(-32'sd1, 5'd0, 3'b000, 5'd1, `OPC_OP_IMM)};
+        sram0.memory[1] = {encode_r(7'b0000000, 5'd0, 5'd1, 3'b000, 5'd2, `OPC_OP_32),        // addw
+                            encode_shift64(6'b000000, 6'd32, 5'd1, 3'b101, 5'd1, `OPC_OP_IMM)}; // srli
+        sram0.memory[2] = {encode_i(32'sd4, 5'd0, 3'b000, 5'd5, `OPC_OP_IMM),                 // addi x5,x0,4
+                            encode_r(7'b0000000, 5'd0, 5'd1, 3'b000, 5'd3, `OPC_OP)};          // add
+        sram0.memory[3] = {encode_r(7'b0000000, 5'd5, 5'd1, 3'b101, 5'd7, `OPC_OP_32),        // srlw
+                            encode_r(7'b0100000, 5'd5, 5'd1, 3'b101, 5'd6, `OPC_OP_32)};       // sraw
+        sram0.memory[4] = {{11'b0, 1'b1, 13'b0, `OPC_SYSTEM},                                  // ebreak
+                            encode_i(32'sd1, 5'd1, 3'b000, 5'd9, `OPC_OP_IMM_32)};             // addiw
 
         @(posedge clk); #1;
         rst = 0;
@@ -86,7 +104,7 @@ module core_rv64_word_ops_tb;
         fork
             wait (dut.halted === 1'b1);
             begin
-                repeat (50) @(posedge clk);
+                repeat (150) @(posedge clk);
                 $display("TIMEOUT: dut.halted never went high");
                 $finish;
             end

--- a/testbench/core_upper_imm_tb.sv
+++ b/testbench/core_upper_imm_tb.sv
@@ -24,7 +24,23 @@ module core_upper_imm_tb;
 
     logic rst = 1;
 
-    core dut (.clk(clk), .rst(rst));
+    logic [31:0] wb_addr;
+    logic [63:0] wb_dat_m2s, wb_dat_s2m;
+    logic [7:0]  wb_sel;
+    logic        wb_we, wb_cyc, wb_stb, wb_ack, wb_err;
+
+    core dut (
+        .clk(clk), .rst(rst),
+        .wb_addr_o(wb_addr), .wb_dat_o(wb_dat_m2s), .wb_dat_i(wb_dat_s2m),
+        .wb_sel_o(wb_sel), .wb_we_o(wb_we), .wb_cyc_o(wb_cyc), .wb_stb_o(wb_stb),
+        .wb_ack_i(wb_ack), .wb_err_i(wb_err)
+    );
+
+    wb4_sram #(.num_words(128)) sram0 (
+        .clk(clk), .rst(rst),
+        .addr_i(wb_addr), .dat_i(wb_dat_m2s), .dat_o(wb_dat_s2m), .sel_i(wb_sel),
+        .ack_o(wb_ack), .err_o(wb_err), .cyc_i(wb_cyc), .stb_i(wb_stb), .we_i(wb_we)
+    );
 
     int pass_count = 0;
     int fail_count = 0;
@@ -39,6 +55,8 @@ module core_upper_imm_tb;
     endtask
 
     initial begin
+        #1; // run after wb4_sram's own time-0 init (zero-fill + $readmemh) -- see core_wb_tb.sv
+
         /*
          * lui x1, 0xFFFFF      x1 = 0xFFFFFFFFFFFFF000  (bit 19 set -> must sign-extend
          *                       negative; the old bug never shifted at all, so this would
@@ -48,10 +66,10 @@ module core_upper_imm_tb;
          * auipc x3, 0x00001    at PC=0x8: x3 = 0x8 + 0x1000 = 0x1008
          * ebreak
          */
-        dut.imem0.mem[0] = encode_u(20'hFFFFF, 5'd1, `OPC_LUI);
-        dut.imem0.mem[1] = encode_u(20'h00001, 5'd2, `OPC_LUI);
-        dut.imem0.mem[2] = encode_u(20'h00001, 5'd3, `OPC_AUIPC);
-        dut.imem0.mem[3] = {11'b0, 1'b1, 13'b0, `OPC_SYSTEM}; // ebreak
+        sram0.memory[0] = {encode_u(20'h00001, 5'd2, `OPC_LUI),
+                            encode_u(20'hFFFFF, 5'd1, `OPC_LUI)};
+        sram0.memory[1] = {{11'b0, 1'b1, 13'b0, `OPC_SYSTEM}, // ebreak
+                            encode_u(20'h00001, 5'd3, `OPC_AUIPC)};
 
         @(posedge clk); #1;
         rst = 0;
@@ -59,7 +77,7 @@ module core_upper_imm_tb;
         fork
             wait (dut.halted === 1'b1);
             begin
-                repeat (50) @(posedge clk);
+                repeat (150) @(posedge clk);
                 $display("TIMEOUT: dut.halted never went high");
                 $finish;
             end

--- a/testbench/core_wb_tb.sv
+++ b/testbench/core_wb_tb.sv
@@ -1,0 +1,170 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+`include "defaults/defaults.sv"
+`include "riscv_encode.sv"
+
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Testbench: core (Wishbone-master FSM) against real bus slaves
+ *
+ * Unlike the five core_*_tb.sv testbenches from the single-cycle
+ * milestone (which poked instructions into a private imem0 and no longer
+ * even compile against this core.sv -- it has no imem0 anymore), this
+ * exercises exactly what's NEW in the FSM rewrite: multi-cycle fetch,
+ * multi-cycle load/store, and routing through a real wb_addr_decoder to
+ * two real slaves (wb4_sram, uart_tx). It deliberately does NOT re-prove
+ * individual ALU ops, branch types, or the *W op family -- that datapath logic is
+ * unchanged from the single-cycle version and was already proven there.
+ * This is the checkpoint before wiring the same four modules into
+ * design/soc.sv for real.
+ *
+ * Instructions are packed two-per-64-bit-word directly into the SRAM's
+ * memory[] array (hierarchical poke, same spirit as the old imem0 pokes)
+ * -- byte address a's instruction lands in memory[a/8][31:0] if a[2]=0,
+ * else memory[a/8][63:32], matching core.sv's own pc[2] half-select.
+ *
+ * The poke is deliberately delayed by #1 past time 0 so it runs AFTER
+ * wb4_sram's own time-0 initial block (zero-fill + $readmemh of whatever
+ * firmware/crt0.hex currently contains) has already finished -- both are
+ * ordinary zero-time initial blocks with no blocking statements of their
+ * own, so by time 1 both are guaranteed complete regardless of which one
+ * the simulator happened to start first. Without this, the poke could
+ * race wb4_sram's own init and get silently overwritten.
+ *
+ * Data addresses (0x100, 0x8000) are deliberately clear of the program's
+ * own instruction footprint (0x00-0x2C) -- this is a shared Von Neumann
+ * memory with no protection, so a data write to an address the program
+ * still occupies would self-modify code that's already been fetched
+ * (harmless in this particular straight-line run, but confusing to
+ * anyone reading the test).
+ */
+module core_wb_tb;
+
+    logic clk = 0;
+    always #5 clk = ~clk;
+    logic rst = 1;
+
+    logic [31:0] wb_addr;
+    logic [63:0] wb_dat_m2s, wb_dat_s2m;
+    logic [7:0]  wb_sel;
+    logic        wb_we, wb_cyc, wb_stb, wb_ack, wb_err;
+
+    core dut (
+        .clk(clk), .rst(rst),
+        .wb_addr_o(wb_addr), .wb_dat_o(wb_dat_m2s), .wb_dat_i(wb_dat_s2m),
+        .wb_sel_o(wb_sel), .wb_we_o(wb_we), .wb_cyc_o(wb_cyc), .wb_stb_o(wb_stb),
+        .wb_ack_i(wb_ack), .wb_err_i(wb_err)
+    );
+
+    logic [31:0] ram_addr, uart_addr;
+    logic [63:0] ram_dat_o, ram_dat_i, uart_dat_o, uart_dat_i;
+    logic [7:0]  ram_sel, uart_sel;
+    logic        ram_we, ram_cyc, ram_stb, ram_ack, ram_err;
+    logic        uart_we, uart_cyc, uart_stb, uart_ack, uart_err;
+
+    wb_addr_decoder decoder0 (
+        .clk(clk), .rst(rst),
+        .addr_i(wb_addr), .dat_i(wb_dat_m2s), .dat_o(wb_dat_s2m), .sel_i(wb_sel),
+        .we_i(wb_we), .cyc_i(wb_cyc), .stb_i(wb_stb), .ack_o(wb_ack), .err_o(wb_err),
+        .ram_addr_o(ram_addr), .ram_dat_o(ram_dat_o), .ram_dat_i(ram_dat_i),
+        .ram_sel_o(ram_sel), .ram_we_o(ram_we), .ram_cyc_o(ram_cyc),
+        .ram_stb_o(ram_stb), .ram_ack_i(ram_ack), .ram_err_i(ram_err),
+        .uart_addr_o(uart_addr), .uart_dat_o(uart_dat_o), .uart_dat_i(uart_dat_i),
+        .uart_sel_o(uart_sel), .uart_we_o(uart_we), .uart_cyc_o(uart_cyc),
+        .uart_stb_o(uart_stb), .uart_ack_i(uart_ack), .uart_err_i(uart_err)
+    );
+
+    wb4_sram #(.num_words(64)) sram0 (
+        .clk(clk), .rst(rst),
+        .addr_i(ram_addr), .dat_i(ram_dat_o), .dat_o(ram_dat_i), .sel_i(ram_sel),
+        .ack_o(ram_ack), .err_o(ram_err), .cyc_i(ram_cyc), .stb_i(ram_stb), .we_i(ram_we)
+    );
+
+    uart_tx uart0 (
+        .clk(clk), .rst(rst),
+        .addr_i(uart_addr), .dat_i(uart_dat_o), .dat_o(uart_dat_i), .sel_i(uart_sel),
+        .ack_o(uart_ack), .err_o(uart_err), .cyc_i(uart_cyc), .stb_i(uart_stb), .we_i(uart_we)
+    );
+
+    int pass_count = 0;
+    int fail_count = 0;
+    task automatic check(string name, logic [63:0] actual, logic [63:0] expected);
+        if (actual === expected) begin
+            pass_count++;
+            $display("PASS: %s", name);
+        end else begin
+            fail_count++;
+            $display("FAIL: %s -- expected %h, got %h", name, expected, actual);
+        end
+    endtask
+
+    initial begin
+        #1; // see header comment: run after wb4_sram's own time-0 init
+
+        /*
+         * addr  idx  instruction                    notes
+         *  0x00   0  addi x1,x0,5                    x1 = 5
+         *  0x04   1  addi x2,x0,10                   x2 = 10
+         *  0x08   2  add  x3,x1,x2                   x3 = 15
+         *  0x0C   3  addi x8,x0,0x100                x8 = data base address
+         *  0x10   4  sw   x3,0(x8)                   mem[0x100] = 15
+         *  0x14   5  lw   x4,0(x8)                   x4 = 15 (round trip through the real bus)
+         *  0x18   6  beq  x3,x4,8      -> 0x20        taken (15==15)
+         *  0x1C   7  addi x5,x0,999                  SKIPPED -- proves the taken branch really skips
+         *  0x20   8  addi x6,x0,72                   x6 = 'H' (0x48)
+         *  0x24   9  lui  x7,0x8                     x7 = 0x8000 (UART TX_DATA)
+         *  0x28  10  sw   x6,0(x7)                   mem-mapped write -> routes to UART, prints 'H'
+         *  0x2C  11  ebreak
+         */
+        sram0.memory[0] = {encode_i(32'sd10, 5'd0, 3'b000, 5'd2, `OPC_OP_IMM),
+                            encode_i(32'sd5,  5'd0, 3'b000, 5'd1, `OPC_OP_IMM)};
+        sram0.memory[1] = {encode_i(32'sh100, 5'd0, 3'b000, 5'd8, `OPC_OP_IMM),
+                            encode_r(7'b0000000, 5'd2, 5'd1, 3'b000, 5'd3, `OPC_OP)};
+        sram0.memory[2] = {encode_i(32'sd0, 5'd8, 3'b010, 5'd4, `OPC_LOAD),
+                            encode_s(32'sd0, 5'd3, 5'd8, 3'b010, `OPC_STORE)};
+        sram0.memory[3] = {encode_i(32'sd999, 5'd0, 3'b000, 5'd5, `OPC_OP_IMM),
+                            encode_b(32'sd8, 5'd4, 5'd3, 3'b000, `OPC_BRANCH)};
+        sram0.memory[4] = {encode_u(20'h8, 5'd7, `OPC_LUI),
+                            encode_i(32'sd72, 5'd0, 3'b000, 5'd6, `OPC_OP_IMM)};
+        sram0.memory[5] = {{11'b0, 1'b1, 13'b0, `OPC_SYSTEM},          // idx11: ebreak (0x2C)
+                            encode_s(32'sd0, 5'd6, 5'd7, 3'b010, `OPC_STORE)}; // idx10: sw x6,0(x7) (0x28)
+
+        @(posedge clk); #1;
+        rst = 0;
+
+        fork
+            wait (dut.halted === 1'b1);
+            begin
+                repeat (150) @(posedge clk);
+                $display("TIMEOUT: dut.halted never went high");
+                $finish;
+            end
+        join_any
+        #1;
+
+        check("x1 (addi)",                     dut.regfile0.gp_registers[1], 64'd5);
+        check("x2 (addi)",                     dut.regfile0.gp_registers[2], 64'd10);
+        check("x3 (add)",                      dut.regfile0.gp_registers[3], 64'd15);
+        check("x4 (lw, RAM round trip over bus)", dut.regfile0.gp_registers[4], 64'd15);
+        check("x5 (skipped by taken beq)",     dut.regfile0.gp_registers[5], 64'd0);
+        check("x6 (addi, UART payload)",       dut.regfile0.gp_registers[6], 64'd72);
+        check("x7 (lui, UART base address)",   dut.regfile0.gp_registers[7], 64'h8000);
+        check("x8 (addi, RAM base address)",   dut.regfile0.gp_registers[8], 64'h100);
+        check("RAM contents at 0x100",         {32'b0, sram0.memory[32][31:0]}, 64'd15);
+        check("UART received exactly one byte", {56'b0, uart0.tx_history_count}, 64'd1);
+        check("UART byte is 'H'",              {56'b0, uart0.tx_history[0]}, 64'h48);
+        check("core halted (ebreak reached)",  {63'b0, dut.halted}, 64'd1);
+
+        $display("");
+        $display("core_wb_tb: %0d passed, %0d failed", pass_count, fail_count);
+        if (fail_count > 0) $display("core_wb_tb: FAILURES PRESENT");
+        $finish;
+    end
+
+endmodule

--- a/testbench/soc_tb.sv
+++ b/testbench/soc_tb.sv
@@ -50,7 +50,15 @@ module soc_tb;
         fork
             wait (dut.core0.halted === 1'b1);
             begin
-                repeat (300) @(posedge clk);
+                /*
+                 * Generous on purpose: unlike the earlier hand-written
+                 * assembly firmware (2 instructions per byte), an -O0 C
+                 * build reloads everything from the stack constantly --
+                 * around 7 memory ops per loop iteration, each costing 5
+                 * bus edges -- so this budget needs real headroom, not
+                 * just margin.
+                 */
+                repeat (3000) @(posedge clk);
                 $display("TIMEOUT: dut.core0.halted never went high -- is firmware/crt0.hex built?");
                 $finish;
             end

--- a/testbench/soc_tb.sv
+++ b/testbench/soc_tb.sv
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+
+/* ------------------------------------------------------------------------- */
+
+
+/*
+ * Testbench: soc -- the actual "hello world over iverilog" milestone
+ *
+ * Unlike core_wb_tb.sv (hand-assembled instructions poked directly into
+ * the SRAM), this instantiates the real top-level design/soc.sv and
+ * relies entirely on wb4_sram.sv's own $readmemh of firmware/crt0.hex --
+ * i.e. this exercises the REAL toolchain-built firmware image, not a
+ * synthetic one. Must be run from a directory one level below the repo
+ * root (e.g. design/) so wb4_sram.sv's hardcoded "../firmware/crt0.hex"
+ * path resolves -- see that file's own $readmemh call.
+ *
+ * If firmware/crt0.hex doesn't exist yet (firmware/Makefile hasn't been
+ * run), $readmemh prints a non-fatal ERROR and the simulation continues
+ * with SRAM still zero-filled. An all-zero instruction word doesn't
+ * match any defined opcode (see testbench/riscv_encode.sv's OPC_* list --
+ * none of them are 7'b0000000), so the core just decodes INVALID forever
+ * and pc free-runs without ever reaching ebreak -- this test times out
+ * rather than false-passing, which is the correct/honest outcome: there
+ * was no real firmware to have printed anything.
+ */
+module soc_tb;
+
+    logic clk = 0;
+    always #5 clk = ~clk;
+    logic rst = 1;
+
+    soc dut (.clk(clk), .rst(rst));
+
+    int pass_count = 0;
+    int fail_count = 0;
+    task automatic check(string name, logic [63:0] actual, logic [63:0] expected);
+        if (actual === expected) begin
+            pass_count++;
+            $display("PASS: %s", name);
+        end else begin
+            fail_count++;
+            $display("FAIL: %s -- expected %h, got %h", name, expected, actual);
+        end
+    endtask
+
+    initial begin
+        @(posedge clk); #1;
+        rst = 0;
+
+        fork
+            wait (dut.core0.halted === 1'b1);
+            begin
+                repeat (300) @(posedge clk);
+                $display("TIMEOUT: dut.core0.halted never went high -- is firmware/crt0.hex built?");
+                $finish;
+            end
+        join_any
+        #1;
+
+        check("UART received 14 bytes",   {56'b0, dut.uart0.tx_history_count}, 64'd14);
+        check("byte 0  'H'",  {56'b0, dut.uart0.tx_history[0]},  64'h48);
+        check("byte 1  'e'",  {56'b0, dut.uart0.tx_history[1]},  64'h65);
+        check("byte 2  'l'",  {56'b0, dut.uart0.tx_history[2]},  64'h6C);
+        check("byte 3  'l'",  {56'b0, dut.uart0.tx_history[3]},  64'h6C);
+        check("byte 4  'o'",  {56'b0, dut.uart0.tx_history[4]},  64'h6F);
+        check("byte 5  ','",  {56'b0, dut.uart0.tx_history[5]},  64'h2C);
+        check("byte 6  ' '",  {56'b0, dut.uart0.tx_history[6]},  64'h20);
+        check("byte 7  'W'",  {56'b0, dut.uart0.tx_history[7]},  64'h57);
+        check("byte 8  'o'",  {56'b0, dut.uart0.tx_history[8]},  64'h6F);
+        check("byte 9  'r'",  {56'b0, dut.uart0.tx_history[9]},  64'h72);
+        check("byte 10 'l'",  {56'b0, dut.uart0.tx_history[10]}, 64'h6C);
+        check("byte 11 'd'",  {56'b0, dut.uart0.tx_history[11]}, 64'h64);
+        check("byte 12 '!'",  {56'b0, dut.uart0.tx_history[12]}, 64'h21);
+        check("byte 13 (LF)", {56'b0, dut.uart0.tx_history[13]}, 64'h0A);
+
+        $display("");
+        $display("soc_tb: %0d passed, %0d failed", pass_count, fail_count);
+        if (fail_count > 0) $display("soc_tb: FAILURES PRESENT");
+        $finish;
+    end
+
+endmodule


### PR DESCRIPTION
## Summary
- Widens the Wishbone bus to 64-bit (`wb4_sram.sv`) and adds a UART TX peripheral (`uart_tx.sv`) plus a 2-slave address decoder (`wb_addr_decoder.sv`)
- Rewrites `core.sv` from the single-cycle datapath into a 3-state (fetch/exec/mem) Wishbone-master FSM, so the CPU is now a real bus master instead of owning private combinational memories
- Wires everything into a top-level `soc.sv`
- Replaces the placeholder firmware with a real hello-world program, built with `riscv64-unknown-elf-gcc` and loaded via `$readmemh`

## Test plan
- [x] `wb4_sram_tb.sv`, `uart_tx_tb.sv`, `wb_addr_decoder_tb.sv` — standalone unit tests per new module, all passing
- [x] `core_wb_tb.sv` — hand-assembled program exercising the FSM against real bus slaves (multi-cycle fetch, taken branch, RAM load/store, UART write), 12/12 passing
- [x] `soc_tb.sv` — the real toolchain-built firmware image, loaded via `wb4_sram`'s own `$readmemh`, printing `Hello, World!` over the UART: 15/15 passing
- [x] `verilator --lint-only -Wall` clean across the full design